### PR TITLE
Adds simple Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: false
+
+language: go
+
+go:
+  - 1.9
+  - master
+
+matrix:
+  # Allow failures if the code fails on unstable development versions of Go.
+  allow_failures:
+    - go: master
+  
+  # Don't block on tip tests. Mark the build as green if tests pass on stable versions.
+  fast_finish: true
+
+# Skip install. Only build with the code in vendor; no `go get`.
+install: true
+
+before_script:
+  - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
+
+script:
+  - go build -v
+  - test -z $(gofmt -s -l $GO_FILES)
+  - go test -v -race ./...
+  - go vet ./...
+
+notifications:
+  email: false


### PR DESCRIPTION
**Purpose of the PR:**

Adds support for Travis CI.

**Fixes #40**

**Notes/Details:**

This will build the main binary, run all tests (including tests for race conditions), and a simple linter. We can add `megacheck` and some other tools once we've cleaned up all the existing warnings.

@Azure/azure-container-registry