### PR TITLE
Update Travis CI to simply call docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+language: go
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 services:
   - docker
 
-before_script:
+before_install:
   - docker build --rm -t acr-builder .
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,12 @@
-sudo: false
+sudo: required
 
 language: go
 
-go:
-  - 1.9
-  - master
-
-matrix:
-  # Allow failures if the code fails on unstable development versions of Go.
-  allow_failures:
-    - go: master
-  
-  # Don't block on tip tests. Mark the build as green if tests pass on stable versions.
-  fast_finish: true
-
-# Skip install. Only build with the code in vendor; no `go get`.
-install: true
+services:
+  - docker
 
 before_script:
-  - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
-
-script:
-  - go build -v
-  - test -z $(gofmt -s -l $GO_FILES)
-  - go test -v -race ./...
-  - go vet ./...
+  - docker build --rm -t acr-builder .
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
 
-language: go
-
 services:
   - docker
 
 before_install:
-  - docker build --rm -t acr-builder .
+  - docker build -t acr-builder .
+
+install: true
 
 notifications:
   email: false


### PR DESCRIPTION
**Purpose of the PR:**

Updates Travis CI to simply call `docker build`.

**Fixes #42**

---

@Azure/azure-container-registry