### PR TITLE
Adds dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.dockerignore
+**/Dockerfile
+.git
+LICENSE
+Makefile
+*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 LICENSE
 Makefile
 *.md
+.vscode

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 **/.dockerignore
-**/Dockerfile
+Dockerfile
 .git
 LICENSE
 Makefile


### PR DESCRIPTION
**Purpose of the PR:**

Adds a basic `dockerignore` file so that some unnecessary files can be filtered out by the daemon.

**Fixes #46**

---

@Azure/azure-container-registry