### PR TITLE
Update to the latest docker cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,18 @@ RUN echo "Running Static Analysis tools..." &&\
     echo "Running tests..." &&\
     go test -cover $(go list ./... | grep -v /vendor/ | grep -v '/tests/') &&\
     echo "Verification successful, building binaries..." &&\
-    GOOS=linux GOARCH=amd64 go build
+    GOOS=linux GOARCH=386 go build
 
-FROM docker/compose:1.16.1
+FROM docker:17.12.0-ce-git
 RUN apk add --update --no-cache \
-    docker \
-    git \
     openssh \
     openssl \
-    ca-certificates
+    ca-certificates \
+    python \
+    py-pip \
+    build-base \
+    && pip install docker-compose \
+    && rm -rf /var/cache/apk/*
 COPY --from=build /go/src/github.com/Azure/acr-builder/acr-builder /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/acr-builder"]
 CMD []


### PR DESCRIPTION
Switch base docker image to docker:17.12.0-ce-git

**Purpose of the PR:**

**Fixes #50**  *[Refer closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)*:

**Notes/Details:**

The change switches to ```docker:17.12.0-ce-git``` as base image which hs preinstalled docker and git. It then installs docker-compose and pip (which is required to install docker-compose and dependencies).

Along with the change, I also change acr-builder to built against 386 because amd64 doesn't work in the new base image.

@Azure/azure-container-registry @shhsu 