### PR TITLE
increase the duration buffer in build timestamp validation

### DIFF
--- a/pkg/driver/build_test.go
+++ b/pkg/driver/build_test.go
@@ -311,7 +311,7 @@ func assertSameContext(t *testing.T, expected []string, actual *build.BuilderCon
 			timeStampFound = true
 			buildTime, err := time.Parse(constants.TimestampFormat, v)
 			assert.Nil(t, err, "Build time format incorrect")
-			assert.WithinDuration(t, time.Now(), buildTime, time.Second*1)
+			assert.WithinDuration(t, time.Now(), buildTime, time.Minute*1)
 		} else {
 			actualEnv[entry] = true
 		}


### PR DESCRIPTION
**Purpose of the PR:**

**Fixes #54 **  *[Refer closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)*:
The unit test tried to validate the build timestamp against now() but sometimes failed as the actual diff was often slightly larger than 1s. Extend the duration buffer to 1m.

**Notes/Details:**

```release-note
```

@Azure/azure-container-registry