### PR TITLE
Output proper error message for missing docker image argument

### DIFF
--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -120,6 +120,9 @@ func (b *Builder) createBuildRequest(composeFile, composeProjectDir,
 		if dockerfile == "" {
 			logrus.Debugf("Docker image is defined, dockerfile will be used for building")
 		}
+		if len(dockerImage) <= 0 {
+			return nil, fmt.Errorf("Image name not specified for docker file '%s'", dockerfile)
+		}
 		if composeProjectDir != "" {
 			return nil, fmt.Errorf("Parameter --%s cannot be used for dockerfile build scenario", constants.ArgNameDockerComposeProjectDir)
 		}


### PR DESCRIPTION
**Purpose of the PR:**
Ensure that build driver checks the image name argument.

**Fixes #11 **  *[Refer closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)*:

@Azure/azure-container-registry