### PR TITLE
fix the registry name for image from docker hub

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -171,7 +171,7 @@ func getRepoDigest(jsonContent string, reference *build.ImageReference) string {
 	// Output: <empty>
 
 	prefix := reference.Repository + "@"
-	if len(reference.Registry) > 0 {
+	if len(reference.Registry) > 0 && reference.Registry != build.DockerHubRegistry {
 		prefix = reference.Registry + "/" + prefix
 	}
 	var digestList []string

--- a/pkg/commands/docker_test.go
+++ b/pkg/commands/docker_test.go
@@ -189,19 +189,28 @@ type repoDigestTestcase struct {
 
 func TestDockerGetRepoDigestSucceed(t *testing.T) {
 	testDockerGetRepoDigest(t, repoDigestTestcase{
-		jsonContent: "[\"registry2/repo2@sha256:testsha2\", \"registry1/repo1@sha256:testsha1\"]",
+		jsonContent: "[\"user2/repo2@sha256:testsha2\", \"user1/repo1@sha256:testsha1\"]",
 		reference: &build.ImageReference{
-			Registry:   "registry1",
-			Repository: "repo1",
+			Registry:   build.DockerHubRegistry,
+			Repository: "user1/repo1",
 		},
 		expectedDigest: "sha256:testsha1",
 	})
 
 	testDockerGetRepoDigest(t, repoDigestTestcase{
-		jsonContent: "[\"repo3@sha256:testsha3\"]",
+		jsonContent: "[\"abc.azurecr.io/repo3@sha256:testsha3\"]",
 		reference: &build.ImageReference{
-			Registry:   "",
+			Registry:   "abc.azurecr.io",
 			Repository: "repo3",
+		},
+		expectedDigest: "sha256:testsha3",
+	})
+
+	testDockerGetRepoDigest(t, repoDigestTestcase{
+		jsonContent: "[\"abc.azurecr.io/group/repo3@sha256:testsha3\"]",
+		reference: &build.ImageReference{
+			Registry:   "abc.azurecr.io",
+			Repository: "group/repo3",
 		},
 		expectedDigest: "sha256:testsha3",
 	})


### PR DESCRIPTION
**Purpose of the PR:**

**Fixes #67  

| name                                 | registry                            | repository          |
|:-----------------------------------|:---------------------------------|:----------------------|
| docker:1.7                          | registry.hub.docker.com | docker               |
| microsoft/dotnet:2.0           | registry.hub.docker.com | microsoft/dotnet |
| registry.azurecr.io/repo      | registry.azurecr.io           | repo                   |

@Azure/azure-container-registry