### PR TITLE
support secret build arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run the following on your project directory to build the project and push to a d
 * `--docker-context-dir` Docker build context. Optional, to be used alongside `--dockerfile`.
 * `--docker-compose-file` Docker Compose file to be invoked for build and push.
 * `--docker-build-arg` Build arguments to be passed to docker build or docker-compose build. This parameter can be specified multiple times.
-* `--docker-secret-build-arg` Build arguments to be passed to docker build or docker-compose build. The argument value contains secret which will be hidden from the log. This parameter can be specified multiple times.
+* `--docker-secret-build-arg` Build arguments to be passed to docker build or docker-compose build. The argument value contains a secret which will be hidden from the log. This parameter can be specified multiple times.
 * `--build-env` Custom environment variables defined for the build process. This parameter can be specified multiple times. (For more details, see `Build Environment`).
 * `--push` Specify if push is required if build is successful.
 * `--verbose` Enable verbose output for debugging.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Run the following on your project directory to build the project and push to a d
 * `--docker-context-dir` Docker build context. Optional, to be used alongside `--dockerfile`.
 * `--docker-compose-file` Docker Compose file to be invoked for build and push.
 * `--docker-build-arg` Build arguments to be passed to docker build or docker-compose build. This parameter can be specified multiple times.
+* `--docker-secret-build-arg` Build arguments to be passed to docker build or docker-compose build. The argument value contains secret which will be hidden from the log. This parameter can be specified multiple times.
 * `--build-env` Custom environment variables defined for the build process. This parameter can be specified multiple times. (For more details, see `Build Environment`).
 * `--push` Specify if push is required if build is successful.
 * `--verbose` Enable verbose output for debugging.

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	flag.StringVar(&dockerImage, constants.ArgNameDockerImage, "", "The image name to build to. This option is only available when building with dockerfile")
 	flag.StringVar(&dockerContextDir, constants.ArgNameDockerContextDir, "", "Context directory for docker build. This option is only available when building with dockerfile.")
 	flag.Var(&buildArgs, constants.ArgNameDockerBuildArg, "Build arguments to be passed to docker build or docker-compose build")
-	flag.Var(&buildSecretArgs, constants.ArgNameDockerSecretBuildArg, "Build arguments to be passed to docker build or docker-compose build. The argument value contains secret which will be hidden from the log.")
+	flag.Var(&buildSecretArgs, constants.ArgNameDockerSecretBuildArg, "Build arguments to be passed to docker build or docker-compose build. The argument value contains a secret which will be hidden from the log.")
 	flag.StringVar(&dockerRegistry, constants.ArgNameDockerRegistry, "", "Docker registry to push to")
 	flag.StringVar(&dockerUser, constants.ArgNameDockerUser, "", "Docker username.")
 	flag.StringVar(&dockerPW, constants.ArgNameDockerPW, "", "Docker password or OAuth identity token.")

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	// required unless the host is properly logged in
 	// if the program is launched in docker container, use option -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker
 	var dockerUser, dockerPW, dockerRegistry string
-	var buildArgs, buildEnvs stringSlice
+	var buildArgs, buildSecretArgs, buildEnvs stringSlice
 	var push, debug bool
 	var buildNumber string
 	flag.StringVar(&buildNumber, constants.ArgNameBuildNumber, "0", fmt.Sprintf("Build number, this argument would set the reserved %s build environment.", constants.ExportsBuildNumber))
@@ -53,6 +53,7 @@ func main() {
 	flag.StringVar(&dockerImage, constants.ArgNameDockerImage, "", "The image name to build to. This option is only available when building with dockerfile")
 	flag.StringVar(&dockerContextDir, constants.ArgNameDockerContextDir, "", "Context directory for docker build. This option is only available when building with dockerfile.")
 	flag.Var(&buildArgs, constants.ArgNameDockerBuildArg, "Build arguments to be passed to docker build or docker-compose build")
+	flag.Var(&buildSecretArgs, constants.ArgNameDockerSecretBuildArg, "Build arguments to be passed to docker build or docker-compose build. The argument value contains secret which will be hidden from the log.")
 	flag.StringVar(&dockerRegistry, constants.ArgNameDockerRegistry, "", "Docker registry to push to")
 	flag.StringVar(&dockerUser, constants.ArgNameDockerUser, "", "Docker username.")
 	flag.StringVar(&dockerPW, constants.ArgNameDockerPW, "", "Docker password or OAuth identity token.")
@@ -73,7 +74,7 @@ func main() {
 		workingDir,
 		gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 		webArchive,
-		buildEnvs, buildArgs, push)
+		buildEnvs, buildArgs, buildSecretArgs, push)
 
 	if err != nil {
 		logrus.Error(err)

--- a/pkg/commands/command_obfuscate.go
+++ b/pkg/commands/command_obfuscate.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/Azure/acr-builder/pkg/constants"
+)
+
+// KeyValueArgumentObfuscator returns a function to scan the argument list and replace the secret argument value with the obfuscation string
+func KeyValueArgumentObfuscator(secretArgs []string) func(args []string) {
+	return func(args []string) {
+		if len(secretArgs) > 0 {
+			for i := 0; i < len(args); i++ {
+				for j := 0; j < len(secretArgs); j++ {
+					if args[i] == secretArgs[j] {
+						index := strings.Index(args[i], "=")
+						if index >= 0 {
+							args[i] = args[i][:index+1] + constants.ObfuscationString
+						} else {
+							args[i] = constants.ObfuscationString
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -44,20 +44,22 @@ func (u *dockerUsernamePassword) Authenticate(runner build.Runner) error {
 
 // NewDockerBuild creates a build target with specified docker file and build parameters
 func NewDockerBuild(dockerfile, contextDir string,
-	buildArgs []string, registry, imageName string) build.Target {
+	buildArgs, buildSecretArgs []string, registry, imageName string) build.Target {
 	return &dockerBuildTask{
-		dockerfile: dockerfile,
-		contextDir: contextDir,
-		buildArgs:  buildArgs,
-		pushTo:     fmt.Sprintf("%s%s", registry, imageName),
+		dockerfile:      dockerfile,
+		contextDir:      contextDir,
+		buildArgs:       buildArgs,
+		buildSecretArgs: buildSecretArgs,
+		pushTo:          fmt.Sprintf("%s%s", registry, imageName),
 	}
 }
 
 type dockerBuildTask struct {
-	dockerfile string
-	contextDir string
-	buildArgs  []string
-	pushTo     string
+	dockerfile      string
+	contextDir      string
+	buildArgs       []string
+	buildSecretArgs []string
+	pushTo          string
 }
 
 func (t *dockerBuildTask) ScanForDependencies(runner build.Runner) ([]build.ImageDependencies, error) {
@@ -93,12 +95,34 @@ func (t *dockerBuildTask) Build(runner build.Runner) error {
 		args = append(args, "--build-arg", buildArg)
 	}
 
+	for _, buildSecretArg := range t.buildSecretArgs {
+		args = append(args, "--build-arg", buildSecretArg)
+	}
+
 	if t.contextDir != "" {
 		args = append(args, t.contextDir)
 	} else {
 		args = append(args, ".")
 	}
-	return runner.ExecuteCmd("docker", args)
+
+	return runner.ExecuteCmdWithObfuscation(func(args []string) {
+		if len(t.buildSecretArgs) > 0 {
+			for i := 0; i < len(args); i++ {
+				for j := 0; j < len(t.buildSecretArgs); j++ {
+					if args[i] == t.buildSecretArgs[j] {
+						index := strings.Index(args[i], "=")
+						if index >= 0 {
+							args[i] = args[i][:index+1] + constants.ObfuscationString
+						} else {
+							args[i] = constants.ObfuscationString
+						}
+						break
+					}
+				}
+			}
+		}
+
+	}, "docker", args)
 }
 
 func (t *dockerBuildTask) Export() []build.EnvVar {

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -105,24 +105,7 @@ func (t *dockerBuildTask) Build(runner build.Runner) error {
 		args = append(args, ".")
 	}
 
-	return runner.ExecuteCmdWithObfuscation(func(args []string) {
-		if len(t.buildSecretArgs) > 0 {
-			for i := 0; i < len(args); i++ {
-				for j := 0; j < len(t.buildSecretArgs); j++ {
-					if args[i] == t.buildSecretArgs[j] {
-						index := strings.Index(args[i], "=")
-						if index >= 0 {
-							args[i] = args[i][:index+1] + constants.ObfuscationString
-						} else {
-							args[i] = constants.ObfuscationString
-						}
-						break
-					}
-				}
-			}
-		}
-
-	}, "docker", args)
+	return runner.ExecuteCmdWithObfuscation(KeyValueArgumentObfuscator(t.buildSecretArgs), "docker", args)
 }
 
 func (t *dockerBuildTask) Export() []build.EnvVar {

--- a/pkg/commands/docker_compose.go
+++ b/pkg/commands/docker_compose.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"strings"
 
 	build "github.com/Azure/acr-builder/pkg"
 	"github.com/Azure/acr-builder/pkg/constants"
@@ -84,23 +83,7 @@ func (t *dockerComposeBuildTask) Build(runner build.Runner) error {
 		args = append(args, "--build-arg", buildSecretArg)
 	}
 
-	return runner.ExecuteCmdWithObfuscation(func(args []string) {
-		if len(t.buildSecretArgs) > 0 {
-			for i := 0; i < len(args); i++ {
-				for j := 0; j < len(t.buildSecretArgs); j++ {
-					if args[i] == t.buildSecretArgs[j] {
-						index := strings.Index(args[i], "=")
-						if index >= 0 {
-							args[i] = args[i][:index+1] + constants.ObfuscationString
-						} else {
-							args[i] = constants.ObfuscationString
-						}
-					}
-				}
-			}
-		}
-
-	}, "docker-compose", args)
+	return runner.ExecuteCmdWithObfuscation(KeyValueArgumentObfuscator(t.buildSecretArgs), "docker-compose", args)
 }
 
 func (t *dockerComposeBuildTask) Export() []build.EnvVar {

--- a/pkg/constants/program_args.go
+++ b/pkg/constants/program_args.go
@@ -55,6 +55,9 @@ const (
 	// ArgNameDockerBuildArg is the parameter name for build args passed in to docker or docker-compose. This parameter is repeatable.
 	ArgNameDockerBuildArg = "docker-build-arg"
 
+	// ArgNameDockerSecretBuildArg is the parameter name for build args passed in to docker or docker-compose. The argument value contains secret which will be hidden from the log. This parameter is repeatable.
+	ArgNameDockerSecretBuildArg = "docker-secret-build-arg"
+
 	// ArgNameBuildEnv is the parameter name for build environment variables to be set. This parameter is repeatable
 	ArgNameBuildEnv = "build-env"
 

--- a/pkg/constants/program_args.go
+++ b/pkg/constants/program_args.go
@@ -55,7 +55,7 @@ const (
 	// ArgNameDockerBuildArg is the parameter name for build args passed in to docker or docker-compose. This parameter is repeatable.
 	ArgNameDockerBuildArg = "docker-build-arg"
 
-	// ArgNameDockerSecretBuildArg is the parameter name for build args passed in to docker or docker-compose. The argument value contains secret which will be hidden from the log. This parameter is repeatable.
+	// ArgNameDockerSecretBuildArg is the parameter name for build args passed in to docker or docker-compose. The argument value contains a secret which will be hidden from the log. This parameter is repeatable.
 	ArgNameDockerSecretBuildArg = "docker-secret-build-arg"
 
 	// ArgNameBuildEnv is the parameter name for build environment variables to be set. This parameter is repeatable

--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -33,7 +33,7 @@ func (b *Builder) Run(buildNumber, composeFile, composeProjectDir,
 	workingDir,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 	webArchive string,
-	buildEnvs, buildArgs []string, push bool,
+	buildEnvs, buildArgs, buildSecretArgs []string, push bool,
 ) (dependencies []build.ImageDependencies, duration time.Duration, err error) {
 	startTime := time.Now()
 	defer func() {
@@ -57,7 +57,7 @@ func (b *Builder) Run(buildNumber, composeFile, composeProjectDir,
 		workingDir,
 		gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 		webArchive,
-		buildArgs, push)
+		buildArgs, buildSecretArgs, push)
 
 	if err != nil {
 		return
@@ -77,7 +77,7 @@ func (b *Builder) createBuildRequest(composeFile, composeProjectDir,
 	workingDir,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 	webArchive string,
-	buildArgs []string, push bool) (*build.Request, error) {
+	buildArgs, buildSecretArgs []string, push bool) (*build.Request, error) {
 	if push && dockerRegistry == "" {
 		return nil, fmt.Errorf("Docker registry is needed for push, use --%s or environment variable %s to provide its value",
 			constants.ArgNameDockerRegistry, constants.ExportsDockerRegistry)
@@ -126,7 +126,7 @@ func (b *Builder) createBuildRequest(composeFile, composeProjectDir,
 		if composeProjectDir != "" {
 			return nil, fmt.Errorf("Parameter --%s cannot be used for dockerfile build scenario", constants.ArgNameDockerComposeProjectDir)
 		}
-		target = commands.NewDockerBuild(dockerfile, dockerContextDir, buildArgs, registrySuffixed, dockerImage)
+		target = commands.NewDockerBuild(dockerfile, dockerContextDir, buildArgs, buildSecretArgs, registrySuffixed, dockerImage)
 	}
 
 	// Use docker-compose as default
@@ -139,7 +139,7 @@ func (b *Builder) createBuildRequest(composeFile, composeProjectDir,
 			return nil, fmt.Errorf("Parameters --%s, --%s, %s cannot be used in docker-compose scenario",
 				constants.ArgNameDockerfile, constants.ArgNameDockerImage, constants.ArgNameDockerContextDir)
 		}
-		target = commands.NewDockerComposeBuild(composeFile, composeProjectDir, buildArgs)
+		target = commands.NewDockerComposeBuild(composeFile, composeProjectDir, buildArgs, buildSecretArgs)
 	}
 
 	return &build.Request{


### PR DESCRIPTION
**Purpose of the PR:**

**Fixes #63 

#### input
--docker-secret-build-arg sk1=sv1 --docker-secret-build-arg sk2=sv2 --docker-build-arg k1=v1

#### log output
--build-arg k1=v1 --build-arg sk1=************* --build-arg sk2=*************

@Azure/azure-container-registry