### PR TITLE
Convert the build duration to milliseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.dll
 *.so
 *.dylib
+acr-builder
+
 
 # Test binary, build with `go test -c`
 *.test

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Azure/acr-builder/pkg/driver"
 	"github.com/Azure/acr-builder/pkg/shell"
@@ -89,6 +90,7 @@ func main() {
 		logrus.Errorf("Failed to serialize dependencies %s", err)
 		os.Exit(constants.GeneralErrorExitCode)
 	}
-	fmt.Printf("\nBuild duration: %s\n", duration)
+
+	fmt.Printf("\nBuild duration: %dms\n", int64(duration)/int64(time.Millisecond))
 	fmt.Printf("\nACR Builder discovered the following dependencies:\n%s\n", string(output))
 }


### PR DESCRIPTION
**Purpose of the PR:**

Build duration is currently being printed out using `%s` in `main.go` which causes formats like `3d5h6s...` for longer times. This makes it harder to process, so instead just always use milliseconds.

**Fixes #72**

@Azure/azure-container-registry