### PR TITLE
Remove build duration from logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,4 +91,5 @@ func main() {
 	}
 
 	fmt.Printf("\nACR Builder discovered the following dependencies:\n%s\n", string(output))
+	fmt.Println("\nBuild complete")
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/Azure/acr-builder/pkg/driver"
 	"github.com/Azure/acr-builder/pkg/shell"
@@ -68,7 +67,7 @@ func main() {
 	}
 
 	builder := driver.NewBuilder(shell.NewRunner())
-	dependencies, duration, err := builder.Run(
+	dependencies, err := builder.Run(
 		buildNumber, composeFile, composeProjectDir,
 		dockerfile, dockerImage, dockerContextDir,
 		dockerUser, dockerPW, dockerRegistry,
@@ -91,6 +90,5 @@ func main() {
 		os.Exit(constants.GeneralErrorExitCode)
 	}
 
-	fmt.Printf("\nBuild duration: %dms\n", int64(duration)/int64(time.Millisecond))
 	fmt.Printf("\nACR Builder discovered the following dependencies:\n%s\n", string(output))
 }

--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -34,11 +34,7 @@ func (b *Builder) Run(buildNumber, composeFile, composeProjectDir,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 	webArchive string,
 	buildEnvs, buildArgs, buildSecretArgs []string, push bool,
-) (dependencies []build.ImageDependencies, duration time.Duration, err error) {
-	startTime := time.Now()
-	defer func() {
-		duration = time.Since(startTime)
-	}()
+) (dependencies []build.ImageDependencies, err error) {
 
 	if dockerRegistry == "" {
 		dockerRegistry = os.Getenv(constants.ExportsDockerRegistry)

--- a/pkg/driver/build_test.go
+++ b/pkg/driver/build_test.go
@@ -686,16 +686,12 @@ func testRun(t *testing.T, tc runTestCase) {
 	runner.PrepareCommandExpectation(tc.expectedCommands)
 	runner.PrepareDigestQuery(tc.expectedDependencies, tc.queryCmdErr)
 	builder := NewBuilder(runner)
-	startTime := time.Now()
-	dependencies, duration, err := builder.Run(tc.buildNumber, tc.composeFile, tc.composeProjectDir,
+	dependencies, err := builder.Run(tc.buildNumber, tc.composeFile, tc.composeProjectDir,
 		tc.dockerfile, tc.dockerImage, tc.dockerContextDir,
 		tc.dockerUser, tc.dockerPW, tc.dockerRegistry,
 		tc.workingDir, tc.gitURL, tc.gitBranch, tc.gitHeadRev,
 		tc.gitPATokenUser, tc.gitPAToken, tc.gitXToken,
 		tc.webArchive, tc.buildEnvs, tc.buildArgs, tc.buildSecretArgs, tc.push)
-	actualDuration := time.Since(startTime)
-	assert.True(t, actualDuration >= duration)
-	assert.True(t, duration+time.Millisecond >= actualDuration)
 	if tc.expectedErr != "" {
 		assert.NotNil(t, err)
 		assert.Regexp(t, regexp.MustCompile(tc.expectedErr), err.Error())


### PR DESCRIPTION
**Purpose of the PR:**

This PR completely removes build duration from the builder's output. Instead, the caller should be measuring the total time of the build request since it needs to anyways. I.e., the caller has to measure any overhead incurred while invoking the builder as well as timeout situations.

@Azure/azure-container-registry