### PR TITLE
add git reversion to image dependency

### DIFF
--- a/tests/mocks/pkg/context.go
+++ b/tests/mocks/pkg/context.go
@@ -94,6 +94,7 @@ type CommandsExpectation struct {
 	Times         *int
 	ErrorMsg      string
 	IsObfuscated  bool
+	QueryResult   string
 }
 
 func (m *MockRunner) PrepareCommandExpectation(commands []CommandsExpectation) {
@@ -106,10 +107,11 @@ func (m *MockRunner) PrepareCommandExpectation(commands []CommandsExpectation) {
 		if cmd.ErrorMsg != "" {
 			returnErr = fmt.Errorf(cmd.ErrorMsg)
 		}
-		if cmd.IsObfuscated {
+		if len(cmd.QueryResult) > 0 {
+			m.On("QueryCmd", cmd.Command, cmd.Args).Return(cmd.QueryResult, returnErr).Times(times)
+		} else if cmd.IsObfuscated {
 			m.On("ExecuteCmdWithObfuscation", mock.Anything, cmd.Command, cmd.Args).Return(returnErr).Times(times)
 		} else {
-
 			m.On("ExecuteCmd", cmd.Command, cmd.Args, mock.Anything).Return(returnErr).Times(times)
 		}
 	}


### PR DESCRIPTION
**Purpose of the PR:**

**Fixes #55**

Sample output:

```json
[
  {
    "image": {
      "registry": "xyz.azurecr.io",
      "repository": "abc",
      "digest": "sha256:0f0321435d1b35a9c233b439447730c75fe4e78bcbb7369a34e0a44a92572cad"
    },
    "runtime-dependency": {
      "registry": "registry.hub.docker.com",
      "repository": "docker",
      "tag": "17.12.0-ce-git",
      "digest": "sha256:14d3f9d0781478fb34802a197666dd7be5df0ffce46be2bd1dc2f0d814cfdcc9"
    },
    "buildtime-dependency": [
      {
        "registry": "registry.hub.docker.com",
        "repository": "golang",
        "tag": "1.9.1-stretch",
        "digest": "sha256:f070a46c4bbb1f8486a64d1529ffc24113a5605ccaf29855b5d1cf6ef03daae2"
      }
    ],
    "git": {
      "git-head-revision": "86ee62732b0a5f396ef3f3984c1d8d28f287833c"
    }
  }
]
```

@Azure/azure-container-registry