### PR TITLE
grok to understand ARG directive and build args

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -83,7 +83,7 @@ func (t *dockerBuildTask) ScanForDependencies(runner build.Runner) ([]build.Imag
 	} else {
 		dockerfile = env.Expand(t.dockerfile)
 	}
-	runtime, buildtime, err := grok.ResolveDockerfileDependencies(dockerfile)
+	runtime, buildtime, err := grok.ResolveDockerfileDependencies(t.buildArgs, dockerfile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/docker_test.go
+++ b/pkg/commands/docker_test.go
@@ -92,7 +92,7 @@ func TestDockerBuildHappy(t *testing.T) {
 	testDockerBuild(t, dockerTestCase{
 		dockerfile: filepath.Join("..", "..", "tests", "resources", "docker-dotnet", "Dockerfile"),
 		contextDir: "contextDir",
-		buildArgs:  []string{"k1=v1", "k2=v2"},
+		buildArgs:  append(testCommon.DotnetExampleMinimalBuildArg, "k1=v1", "k2=v2"),
 		registry:   testCommon.DotnetExampleTargetRegistryName + "/",
 		imageName:  testCommon.DotnetExampleTargetImageName,
 		expectedCommands: []test.CommandsExpectation{
@@ -100,7 +100,7 @@ func TestDockerBuildHappy(t *testing.T) {
 				Command:      "docker",
 				IsObfuscated: true,
 				Args: []string{"build", "-f", filepath.Join("..", "..", "tests", "resources", "docker-dotnet", "Dockerfile"),
-					"-t", testCommon.DotnetExampleFullImageName, "--build-arg", "k1=v1", "--build-arg", "k2=v2", "contextDir"},
+					"-t", testCommon.DotnetExampleFullImageName, "--build-arg", testCommon.DotnetExampleMinimalBuildArg[0], "--build-arg", "k1=v1", "--build-arg", "k2=v2", "contextDir"},
 			},
 		},
 	})
@@ -170,7 +170,8 @@ func testDockerScanDependencies(t *testing.T, tc dockerDependenciesTestCase) {
 	runner.SetContext(build.NewContext([]build.EnvVar{
 		{Name: "project_root", Value: filepath.Join("..", "..", "tests", "resources", "docker-dotnet")},
 	}, []build.EnvVar{}))
-	target := NewDockerBuild(tc.path, "", []string{}, []string{}, testCommon.DotnetExampleTargetRegistryName+"/", testCommon.DotnetExampleTargetImageName, false, false)
+	target := NewDockerBuild(tc.path, "", testCommon.DotnetExampleMinimalBuildArg,
+		[]string{}, testCommon.DotnetExampleTargetRegistryName+"/", testCommon.DotnetExampleTargetImageName, false, false)
 	dependencies, err := target.ScanForDependencies(runner)
 	if tc.expectedErr == "" {
 		assert.Nil(t, err)

--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/acr-builder/pkg/grok"
 	"github.com/Azure/acr-builder/pkg/workflow"
 
 	build "github.com/Azure/acr-builder/pkg"
@@ -124,7 +125,7 @@ func (b *Builder) createBuildRequest(
 func parseUserDefined(buildEnvs []string) ([]build.EnvVar, error) {
 	userDefined := []build.EnvVar{}
 	for _, env := range buildEnvs {
-		k, v, err := parseAssignment(env)
+		k, v, err := grok.ParseAssignment(env)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing build environment \"%s\"", err)
 		}
@@ -135,14 +136,6 @@ func parseUserDefined(buildEnvs []string) ([]build.EnvVar, error) {
 		userDefined = append(userDefined, *envVar)
 	}
 	return userDefined, nil
-}
-
-func parseAssignment(in string) (string, string, error) {
-	values := strings.SplitN(in, "=", 2)
-	if len(values) != 2 {
-		return "", "", fmt.Errorf("%s cannot be split into 2 tokens with '='", in)
-	}
-	return values[0], values[1], nil
 }
 
 func dependencyTask(target build.Target) workflow.EvaluationTask {

--- a/pkg/driver/build_test.go
+++ b/pkg/driver/build_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Azure/acr-builder/pkg/constants"
+	"github.com/Azure/acr-builder/pkg/grok"
 
 	build "github.com/Azure/acr-builder/pkg"
 	"github.com/Azure/acr-builder/pkg/commands"
@@ -305,7 +306,7 @@ func assertSameContext(t *testing.T, expected []string, actual *build.BuilderCon
 	actualEnv := map[string]bool{}
 	timeStampFound := false
 	for _, entry := range actual.Export() {
-		k, v, err := parseAssignment(entry)
+		k, v, err := grok.ParseAssignment(entry)
 		assert.Nil(t, err)
 		if k == constants.ExportsBuildTimestamp {
 			timeStampFound = true

--- a/pkg/grok/docker_file.go
+++ b/pkg/grok/docker_file.go
@@ -10,41 +10,66 @@ import (
 )
 
 // ResolveDockerfileDependencies given a docker file, resolve its dependencies
-func ResolveDockerfileDependencies(path string) (string, []string, error) {
+func ResolveDockerfileDependencies(buildArgs []string, path string) (string, []string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", nil, fmt.Errorf("Error opening dockerfile %s, error: %s", path, err)
 	}
 	scanner := bufio.NewScanner(file)
-
+	context, err := parseBuildArgs(buildArgs)
+	if err != nil {
+		return "", nil, err
+	}
 	originLookup := map[string]string{} // given an alias, look up its origin
 	allOrigins := map[string]bool{}     // set of all origins
 	var origin string
 	for scanner.Scan() {
 		line := scanner.Text()
 		tokens := strings.Fields(line)
-		if len(tokens) > 0 && strings.ToLower(tokens[0]) == "from" {
-			if len(tokens) < 2 {
-				return "", nil, fmt.Errorf("Unable to understand line %s", line)
-			}
-
-			var image = tokens[1]
-			var found bool
-			origin, found = originLookup[image]
-			if !found {
-				allOrigins[image] = true
-				origin = image
-			}
-
-			if len(tokens) > 2 {
-				if len(tokens) < 4 || strings.ToLower(tokens[2]) != "as" {
+		if len(tokens) > 0 {
+			switch strings.ToUpper(tokens[0]) {
+			case "FROM":
+				if len(tokens) < 2 {
 					return "", nil, fmt.Errorf("Unable to understand line %s", line)
 				}
-				alias := tokens[3]
-				originLookup[alias] = origin
-				// Just ignore the rest of the tokens...
-				if len(tokens) > 4 {
-					logrus.Debugf("Ignoring chunks from FROM clause: %v", tokens[4:])
+				var image = os.Expand(tokens[1], func(key string) string {
+					return context[key]
+				})
+				var found bool
+				origin, found = originLookup[image]
+				if !found {
+					allOrigins[image] = true
+					origin = image
+				}
+
+				if len(tokens) > 2 {
+					if len(tokens) < 4 || strings.ToLower(tokens[2]) != "as" {
+						return "", nil, fmt.Errorf("Unable to understand line %s", line)
+					}
+					// NOTE: alias cannot contain variables it seems. So we don't call context.Expand on it
+					alias := tokens[3]
+					originLookup[alias] = origin
+					// Just ignore the rest of the tokens...
+					if len(tokens) > 4 {
+						logrus.Debugf("Ignoring chunks from FROM clause: %v", tokens[4:])
+					}
+				}
+			case "ARG":
+				if len(tokens) < 2 {
+					return "", nil, fmt.Errorf("Dockerfile syntax requires ARG directive to have exactly 1 argument. LINE: %s", line)
+				}
+				if strings.Contains(tokens[1], "=") {
+					varName, varValue, err := ParseAssignment(tokens[1])
+					if err != nil {
+						return "", nil, fmt.Errorf("Unable to parse assignment %s, error: %s", tokens[1], err)
+					}
+					// This line matches docker's behavior here
+					// 1. If build arg is passed in, the value will not override
+					// 2. It is actually allowed for same ARG to be specified more than once in a Dockerfile
+					//    However the subsequent value would be ignored instead of overriding the previous
+					if _, found := context[varName]; !found {
+						context[varName] = varValue
+					}
 				}
 			}
 		}
@@ -64,4 +89,25 @@ func ResolveDockerfileDependencies(path string) (string, []string, error) {
 	}
 	// assert len(buildtimeDependencies) == len(allOrigins)-1
 	return origin, buildtimeDependencies, nil
+}
+
+func parseBuildArgs(args []string) (map[string]string, error) {
+	result := map[string]string{}
+	for _, assignment := range args {
+		name, value, err := ParseAssignment(assignment)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+// ParseAssignment is the helper to help parse an assignment statement, I.E. var=value. No space allowed
+func ParseAssignment(in string) (string, string, error) {
+	values := strings.SplitN(in, "=", 2)
+	if len(values) != 2 {
+		return "", "", fmt.Errorf("%s cannot be split into 2 tokens with '='", in)
+	}
+	return values[0], values[1], nil
 }

--- a/pkg/grok/docker_file_test.go
+++ b/pkg/grok/docker_file_test.go
@@ -11,11 +11,16 @@ import (
 
 func TestResolveDockerfileDependencies(t *testing.T) {
 	path := filepath.Join("..", "..", "tests", "resources", "docker-dotnet", "Dockerfile")
-	runtime, buildtimes, err := ResolveDockerfileDependencies(path)
+	buildArgs := append(testCommon.DotnetExampleMinimalBuildArg, "build_version=2.0.5")
+	runtime, buildtimes, err := ResolveDockerfileDependencies(buildArgs, path)
 	if err != nil {
 		assert.Failf(t, "Failed", "Scenario failed with unexpected error: %s", err)
 	}
-	testCommon.AssertSameDependencies(t, []build.ImageDependencies{testCommon.DotnetExampleDependencies}, []build.ImageDependencies{
+	testCommon.AssertSameDependencies(t, []build.ImageDependencies{*testCommon.NewImageDependencies(
+		testCommon.DotnetExampleFullImageName,
+		"microsoft/aspnetcore:2.0.6",
+		[]string{"microsoft/aspnetcore-build:2.0.5", "imaginary/cert-generator:1.0"},
+	)}, []build.ImageDependencies{
 		*testCommon.NewImageDependencies(testCommon.DotnetExampleFullImageName, runtime, buildtimes),
 	})
 }

--- a/tests/resources/docker-dotnet/Dockerfile
+++ b/tests/resources/docker-dotnet/Dockerfile
@@ -1,13 +1,15 @@
 ## This dockerfile is just a test resource and is not buildable
-
-FROM microsoft/aspnetcore:2.0 AS base
+ARG runtime_version=2.0.6
+FROM microsoft/aspnetcore:${runtime_version} AS base
 WORKDIR /app
 EXPOSE 80
 
 FROM base AS secondary
 RUN nothing
 
-FROM microsoft/aspnetcore-build:2.0 AS builder
+ARG build_image
+ARG build_version=2.0
+FROM microsoft/$build_image:$build_version AS builder
 WORKDIR /src
 COPY *.sln ./
 COPY Web/Web.csproj Web/

--- a/tests/testCommon/helpers.go
+++ b/tests/testCommon/helpers.go
@@ -117,9 +117,12 @@ const DotnetExampleFullImageName = DotnetExampleTargetRegistryName + "/" + Dotne
 // DotnetExampleDependencies links to the project in ${workspaceRoot}/tests/resources/docker-dotnet
 var DotnetExampleDependencies = *NewImageDependencies(
 	DotnetExampleFullImageName,
-	"microsoft/aspnetcore:2.0",
+	"microsoft/aspnetcore:2.0.6",
 	[]string{"microsoft/aspnetcore-build:2.0", "imaginary/cert-generator:1.0"},
 )
+
+// DotnetExampleMinimalBuildArg is the minimal build arg required for dotnet example
+var DotnetExampleMinimalBuildArg = []string{"build_image=aspnetcore-build"}
 
 // AssertSameEnv asserts two sets environment variable are the same
 func AssertSameEnv(t *testing.T, expected, actual []build.EnvVar) {


### PR DESCRIPTION
**Purpose of the PR:**

**Fixes #**
https://github.com/Azure/acr-builder/issues/83


**Notes/Details:**

dependency scanning now knows build args

```release-note
```

@Azure/azure-container-registry