### PR TITLE
Allow support for multiple tags; automatic pushing to multi-tag; ...

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 	// if the program is launched in docker container, use option -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker
 	var dockerUser, dockerPW, dockerRegistry string
 	var buildArgs, buildSecretArgs, buildEnvs stringSlice
+	var tags stringSlice
 	var pull, noCache, push, debug bool
 	var buildNumber string
 	flag.StringVar(&buildNumber, constants.ArgNameBuildNumber, "0", fmt.Sprintf("Build number, this argument would set the reserved %s build environment.", constants.ExportsBuildNumber))
@@ -60,6 +61,7 @@ func main() {
 	flag.StringVar(&dockerRegistry, constants.ArgNameDockerRegistry, "", "Docker registry to push to")
 	flag.StringVar(&dockerUser, constants.ArgNameDockerUser, "", "Docker username.")
 	flag.StringVar(&dockerPW, constants.ArgNameDockerPW, "", "Docker password or OAuth identity token.")
+	flag.Var(&tags, "t", "Custom tags to create for the image during build")
 	flag.Var(&buildEnvs, constants.ArgNameBuildEnv, "Custom environment variables defined for the build process")
 	flag.BoolVar(&pull, constants.ArgNamePull, false, "Attempt to pull a newer version of the base images")
 	flag.BoolVar(&noCache, constants.ArgNameNoCache, false, "Not using any cached layer when building the image")
@@ -93,7 +95,7 @@ func main() {
 		workingDir,
 		gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 		webArchive,
-		buildEnvs, buildArgs, buildSecretArgs, pull, noCache, push)
+		buildEnvs, buildArgs, buildSecretArgs, pull, noCache, push, tags)
 
 	if err != nil {
 		logrus.Error(err)

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -53,7 +53,7 @@ func (u *dockerUsernamePassword) Authenticate(runner build.Runner) error {
 
 // NewDockerBuild creates a build target with specified docker file and build parameters
 func NewDockerBuild(dockerfile, contextDir string,
-	buildArgs, buildSecretArgs []string, registry, imageName string, pull, noCache bool) build.Target {
+	buildArgs, buildSecretArgs []string, registry, imageName string, pull, noCache bool, tags []string) build.Target {
 
 	var pushTo string
 	// If imageName is empty, skip push.
@@ -70,6 +70,7 @@ func NewDockerBuild(dockerfile, contextDir string,
 		pushTo:          pushTo,
 		pull:            pull,
 		noCache:         noCache,
+		tags:            tags,
 	}
 }
 
@@ -81,6 +82,7 @@ type dockerBuildTask struct {
 	pushTo          string
 	pull            bool
 	noCache         bool
+	tags            []string
 }
 
 func (t *dockerBuildTask) ScanForDependencies(runner build.Runner) ([]build.ImageDependencies, error) {
@@ -119,6 +121,11 @@ func (t *dockerBuildTask) Build(runner build.Runner) error {
 
 	if t.pushTo != "" {
 		args = append(args, "-t", t.pushTo)
+
+		// Append custom tags
+		for _, tag := range t.tags {
+			args = append(args, "-t", fmt.Sprintf("%s:%s", t.pushTo, tag))
+		}
 	}
 
 	for _, buildArg := range t.buildArgs {

--- a/pkg/commands/docker_test.go
+++ b/pkg/commands/docker_test.go
@@ -58,7 +58,7 @@ func testDockerBuild(t *testing.T, tc dockerTestCase) {
 	runner := new(test.MockRunner)
 	runner.PrepareCommandExpectation(tc.expectedCommands)
 	defer runner.AssertExpectations(t)
-	target := NewDockerBuild(tc.dockerfile, tc.contextDir, tc.buildArgs, tc.buildSecretArgs, tc.registry, tc.imageName, tc.pull, tc.noCache)
+	target := NewDockerBuild(tc.dockerfile, tc.contextDir, tc.buildArgs, tc.buildSecretArgs, tc.registry, tc.imageName, tc.pull, tc.noCache, nil)
 	err := target.Build(runner)
 	if tc.expectedExecutionErr != "" {
 		assert.NotNil(t, err)
@@ -107,7 +107,7 @@ func TestDockerBuildHappy(t *testing.T) {
 }
 
 func TestExport(t *testing.T) {
-	task := NewDockerBuild("myDockerfile", "myContextDir", []string{}, []string{}, "myRegistry/", "myImage", false, false)
+	task := NewDockerBuild("myDockerfile", "myContextDir", []string{}, []string{}, "myRegistry/", "myImage", false, false, nil)
 	exports := task.Export()
 	testCommon.AssertSameEnv(t, []build.EnvVar{
 		{Name: constants.ExportsDockerfilePath, Value: "myDockerfile"},
@@ -120,7 +120,7 @@ func testDockerPush(t *testing.T, tc dockerTestCase) {
 	runner := new(test.MockRunner)
 	runner.PrepareCommandExpectation(tc.expectedCommands)
 	defer runner.AssertExpectations(t)
-	target := NewDockerBuild(tc.dockerfile, tc.contextDir, tc.buildArgs, tc.buildSecretArgs, tc.registry, tc.imageName, tc.pull, tc.noCache)
+	target := NewDockerBuild(tc.dockerfile, tc.contextDir, tc.buildArgs, tc.buildSecretArgs, tc.registry, tc.imageName, tc.pull, tc.noCache, nil)
 	err := target.Push(runner)
 	if tc.expectedExecutionErr != "" {
 		assert.NotNil(t, err)
@@ -171,7 +171,7 @@ func testDockerScanDependencies(t *testing.T, tc dockerDependenciesTestCase) {
 		{Name: "project_root", Value: filepath.Join("..", "..", "tests", "resources", "docker-dotnet")},
 	}, []build.EnvVar{}))
 	target := NewDockerBuild(tc.path, "", testCommon.DotnetExampleMinimalBuildArg,
-		[]string{}, testCommon.DotnetExampleTargetRegistryName+"/", testCommon.DotnetExampleTargetImageName, false, false)
+		[]string{}, testCommon.DotnetExampleTargetRegistryName+"/", testCommon.DotnetExampleTargetImageName, false, false, nil)
 	dependencies, err := target.ScanForDependencies(runner)
 	if tc.expectedErr == "" {
 		assert.Nil(t, err)

--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -33,7 +33,7 @@ func (b *Builder) Run(buildNumber,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 	webArchive string,
 	buildEnvs, buildArgs, buildSecretArgs []string, pull, noCache, push bool,
-) (dependencies []build.ImageDependencies, err error) {
+	tags []string) (dependencies []build.ImageDependencies, err error) {
 
 	if dockerRegistry == "" {
 		dockerRegistry = os.Getenv(constants.ExportsDockerRegistry)
@@ -52,7 +52,7 @@ func (b *Builder) Run(buildNumber,
 		workingDir,
 		gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 		webArchive,
-		buildArgs, buildSecretArgs, pull, noCache, push)
+		buildArgs, buildSecretArgs, pull, noCache, push, tags)
 
 	if err != nil {
 		return
@@ -63,6 +63,7 @@ func (b *Builder) Run(buildNumber,
 	if err == nil {
 		dependencies = buildWorkflow.GetOutputs().ImageDependencies
 	}
+
 	return
 }
 
@@ -72,7 +73,7 @@ func (b *Builder) createBuildRequest(
 	workingDir,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
 	webArchive string,
-	buildArgs, buildSecretArgs []string, pull, noCache, push bool) (*build.Request, error) {
+	buildArgs, buildSecretArgs []string, pull, noCache, push bool, tags []string) (*build.Request, error) {
 	if push && dockerRegistry == "" {
 		return nil, fmt.Errorf("Docker registry is needed for push, use --%s or environment variable %s to provide its value",
 			constants.ArgNameDockerRegistry, constants.ExportsDockerRegistry)
@@ -108,7 +109,7 @@ func (b *Builder) createBuildRequest(
 		return nil, err
 	}
 
-	target := commands.NewDockerBuild(dockerfile, dockerContextDir, buildArgs, buildSecretArgs, registrySuffixed, dockerImage, pull, noCache)
+	target := commands.NewDockerBuild(dockerfile, dockerContextDir, buildArgs, buildSecretArgs, registrySuffixed, dockerImage, pull, noCache, tags)
 
 	return &build.Request{
 		DockerRegistry:    registrySuffixed,

--- a/pkg/driver/build_test.go
+++ b/pkg/driver/build_test.go
@@ -416,7 +416,7 @@ func TestCreateBuildRequestNoParams(t *testing.T) {
 			Targets: []build.SourceTarget{
 				{
 					Source: localSource,
-					Builds: []build.Target{commands.NewDockerBuild("", "", nil, nil, "", "", false, false)},
+					Builds: []build.Target{commands.NewDockerBuild("", "", nil, nil, "", "", false, false, nil)},
 				},
 			},
 		},
@@ -439,7 +439,7 @@ func TestCreateBuildRequestWithGitPATokenDockerfile(t *testing.T) {
 	pull := true
 	noCache := false
 	dockerBuildTarget := commands.NewDockerBuild(dockerfile, contextDir,
-		buildArgs, buildSecretArgs, registry+"/", imageName, pull, noCache)
+		buildArgs, buildSecretArgs, registry+"/", imageName, pull, noCache, nil)
 	gitCred, err := commands.NewGitPersonalAccessToken(gitUser, gitPassword)
 	assert.Nil(t, err)
 	gitSource := commands.NewGitSource(gitAddress, branch, headRev, targetDir, gitCred)
@@ -520,7 +520,7 @@ func testCreateBuildRequest(t *testing.T, tc createBuildRequestTestCase) {
 		tc.dockerUser, tc.dockerPW, tc.dockerRegistry, tc.workingDir,
 		tc.gitURL, tc.gitBranch, tc.gitHeadRev,
 		tc.gitPATokenUser, tc.gitPAToken, tc.gitXToken,
-		tc.webArchive, tc.buildArgs, tc.buildSecretArgs, tc.pull, tc.noCache, tc.push)
+		tc.webArchive, tc.buildArgs, tc.buildSecretArgs, tc.pull, tc.noCache, tc.push, nil)
 
 	if tc.expectedError != "" {
 		assert.NotNil(t, err)
@@ -730,7 +730,7 @@ func testRun(t *testing.T, tc runTestCase) {
 		tc.dockerUser, tc.dockerPW, tc.dockerRegistry,
 		tc.workingDir, tc.gitURL, tc.gitBranch, tc.gitHeadRev,
 		tc.gitPATokenUser, tc.gitPAToken, tc.gitXToken,
-		tc.webArchive, tc.buildEnvs, tc.buildArgs, tc.buildSecretArgs, tc.pull, tc.noCache, tc.push)
+		tc.webArchive, tc.buildEnvs, tc.buildArgs, tc.buildSecretArgs, tc.pull, tc.noCache, tc.push, nil)
 	if tc.expectedErr != "" {
 		assert.NotNil(t, err)
 		assert.Regexp(t, regexp.MustCompile(tc.expectedErr), err.Error())


### PR DESCRIPTION
**Purpose of the PR:**

Add support for multiple tags; automatic multi-tag pushes; custom tags.
This follows a similar pattern Docker does with build, you can just chain `-t` indefinitely.

Note that the functionality is a bit different in that we don't support `{image}:tag`, since we never really did to begin with. We could change this, but for now we just always use the image name passed in and then append the tags to the same image name, no changing of image names with multi-tag for now.

Example:

```
./acr-builder --docker-registry swankyregistry.azurecr.io --docker-user ehotinger --docker-password youwish --docker-file Dockerfile --docker-context-dir . --push --docker-image acr-builder -t fancytag -t swankytag -t happytag
```

**Fixes #94** 

**Notes/Details:**

The way `docker push` is set up, all layers for all tags will automatically be processed.

PS: you'll still always get `:latest` by default even if you don't have a custom tag.

@Azure/azure-container-registry 