### PR TITLE
Support multiple custom images

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ var (
 )
 
 func main() {
-	var dockerfile, dockerImage, dockerContextDir string
+	var dockerfile, dockerContextDir string
+	var dockerImages stringSlice
 	var workingDir string
 	var gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken string
 	var webArchive string
@@ -53,7 +54,7 @@ func main() {
 	flag.StringVar(&gitXToken, constants.ArgNameGitXToken, "", "Git OAuth x access token.")
 	flag.StringVar(&webArchive, constants.ArgNameWebArchive, "", "Archive file of the source. Must be a web-url and in tar.gz format")
 	flag.StringVar(&dockerfile, constants.ArgNameDockerfile, "", "Dockerfile to build. If choosing to build a dockerfile")
-	flag.StringVar(&dockerImage, constants.ArgNameDockerImage, "", "The image name to build to. This option is only available when building with dockerfile")
+	flag.Var(&dockerImages, constants.ArgNameDockerImage, "The image names to build to. This option is only available when building with dockerfile")
 	flag.StringVar(&dockerContextDir, constants.ArgNameDockerContextDir, "", "Context directory for docker build. This option is only available when building with dockerfile.")
 	flag.Var(&buildArgs, constants.ArgNameDockerBuildArg, "Build arguments to be passed to docker build build")
 	flag.Var(&buildSecretArgs, constants.ArgNameDockerSecretBuildArg, "Build arguments to be passed to docker build build. The argument value contains a secret which will be hidden from the log.")
@@ -88,7 +89,7 @@ func main() {
 	builder := driver.NewBuilder(shell.NewRunner())
 	dependencies, err := builder.Run(
 		buildNumber,
-		dockerfile, dockerImage, dockerContextDir,
+		dockerfile, dockerImages, dockerContextDir,
 		dockerUser, dockerPW, dockerRegistry,
 		workingDir,
 		gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,

--- a/pkg/constants/exports.go
+++ b/pkg/constants/exports.go
@@ -14,9 +14,6 @@ const (
 	// ExportsDockerBuildContext is the docker build context directory
 	ExportsDockerBuildContext = dockerDomainPrefix + "CONTEXT"
 
-	// ExportsDockerPushImage is the image name to push to
-	ExportsDockerPushImage = dockerDomainPrefix + "PUSH_TO"
-
 	// ExportsDockerRegistry is the docker registry to push to
 	ExportsDockerRegistry = dockerDomainPrefix + "REGISTRY"
 

--- a/pkg/constants/program_args.go
+++ b/pkg/constants/program_args.go
@@ -32,7 +32,7 @@ const (
 	ArgNameDockerfile = "docker-file"
 
 	// ArgNameDockerImage is the parameter name for docker image (registry url must be excluded from the image name parameter)
-	ArgNameDockerImage = "docker-image"
+	ArgNameDockerImage = "t"
 
 	// ArgNameDockerContextDir is the parameter name for docker context directory
 	ArgNameDockerContextDir = "docker-context-dir"

--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -26,8 +26,8 @@ func NewBuilder(runner build.Runner) *Builder {
 }
 
 // Run is the main body of the acr-builder
-func (b *Builder) Run(buildNumber,
-	dockerfile, dockerImage, dockerContextDir,
+func (b *Builder) Run(buildNumber string,
+	dockerfile string, dockerImages []string, dockerContextDir,
 	dockerUser, dockerPW, dockerRegistry,
 	workingDir,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
@@ -47,7 +47,7 @@ func (b *Builder) Run(buildNumber,
 
 	var request *build.Request
 	request, err = b.createBuildRequest(
-		dockerfile, dockerImage, dockerContextDir,
+		dockerfile, dockerImages, dockerContextDir,
 		dockerUser, dockerPW, dockerRegistry,
 		workingDir,
 		gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
@@ -67,7 +67,7 @@ func (b *Builder) Run(buildNumber,
 }
 
 func (b *Builder) createBuildRequest(
-	dockerfile, dockerImage, dockerContextDir,
+	dockerfile string, dockerImages []string, dockerContextDir,
 	dockerUser, dockerPW, dockerRegistry,
 	workingDir,
 	gitURL, gitBranch, gitHeadRev, gitPATokenUser, gitPAToken, gitXToken,
@@ -78,9 +78,9 @@ func (b *Builder) createBuildRequest(
 			constants.ArgNameDockerRegistry, constants.ExportsDockerRegistry)
 	}
 
-	if push && dockerImage == "" {
-		return nil, fmt.Errorf("Docker image is needed for push, use --%s or environment variable %s to provide its value",
-			constants.ArgNameDockerImage, constants.ExportsDockerPushImage)
+	if push && len(dockerImages) <= 0 {
+		return nil, fmt.Errorf("Docker image is needed for push, use --%s to provide its value",
+			constants.ArgNameDockerImage)
 	}
 
 	var registrySuffixed, registryNoSuffix string
@@ -108,7 +108,7 @@ func (b *Builder) createBuildRequest(
 		return nil, err
 	}
 
-	target := commands.NewDockerBuild(dockerfile, dockerContextDir, buildArgs, buildSecretArgs, registrySuffixed, dockerImage, pull, noCache)
+	target := commands.NewDockerBuild(dockerfile, dockerContextDir, buildArgs, buildSecretArgs, registrySuffixed, dockerImages, pull, noCache)
 
 	return &build.Request{
 		DockerRegistry:    registrySuffixed,


### PR DESCRIPTION
**Purpose of the PR:**

- Support tagging multiple custom images.
- Support multiple pushes from the builder.
- Include dependencies of all new images and tags in the output.

Example:

```
sudo ./acr-builder --docker-registry myregistry.azurecr.io --docker-user ehotinger --docker-password somepassword --docker-file Dockerfile --docker-context-dir .  -t acr-builder:newtag -t acr-builder2:anothertag -t acr-builder2:footag --push
```

**Fixes #95**

@Azure/azure-container-registry