### PR TITLE
Pretty print dependencies

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 		os.Exit(constants.GeneralErrorExitCode)
 	}
 
-	output, err := json.Marshal(dependencies)
+	output, err := json.MarshalIndent(dependencies, "", "    ")
 	if err != nil {
 		logrus.Errorf("Failed to serialize dependencies %s", err)
 		os.Exit(constants.GeneralErrorExitCode)


### PR DESCRIPTION
Before:

```
ACR Builder discovered the following dependencies:
[{"image":null,"runtime-dependency":{"registry":"registry.hub.docker.com","repository":"docker","tag":"17.12.0-ce-git","digest":"sha256:14d3f9d0781478fb34802a197666dd7be5df0ffce46be2bd1dc2f0d814cfdcc9"},"buildtime-dependency":[{"registry":"registry.hub.docker.com","repository":"golang","tag":"1.9.1-stretch","digest":"sha256:f070a46c4bbb1f8486a64d1529ffc24113a5605ccaf29855b5d1cf6ef03daae2"}]}]
```

After:

```
ACR Builder discovered the following dependencies:
[
    {
        "image": null,
        "runtime-dependency": {
            "registry": "registry.hub.docker.com",
            "repository": "docker",
            "tag": "17.12.0-ce-git",
            "digest": "sha256:14d3f9d0781478fb34802a197666dd7be5df0ffce46be2bd1dc2f0d814cfdcc9"
        },
        "buildtime-dependency": [
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "1.9.1-stretch",
                "digest": "sha256:f070a46c4bbb1f8486a64d1529ffc24113a5605ccaf29855b5d1cf6ef03daae2"
            }
        ]
    }
]
```