### PR TITLE
Always use latest as a tag in the dependency output unless digest

### DIFF
--- a/pkg/build.go
+++ b/pkg/build.go
@@ -103,6 +103,14 @@ func NewImageReference(path string) (*ImageReference, error) {
 	}
 	if tagged, ok := ref.(reference.Tagged); ok {
 		result.Tag = tagged.Tag()
+	} else {
+		// Append the "latest" Tag if the path doesn't have a tag AND
+		// it isn't a manifest. E.g., the path is "golang"
+		// In this case we don't want the user to receive automatic
+		// updates since they've specified an absolute digest.
+		if !strings.Contains(path, "@") {
+			result.Tag = "latest"
+		}
 	}
 	return result, nil
 }

--- a/pkg/build.go
+++ b/pkg/build.go
@@ -103,13 +103,6 @@ func NewImageReference(path string) (*ImageReference, error) {
 	}
 	if tagged, ok := ref.(reference.Tagged); ok {
 		result.Tag = tagged.Tag()
-	} else {
-		// Append the "latest" Tag if the path doesn't have a tag AND
-		// it isn't a manifest. E.g., the path is "golang".
-		// If the user specified a digest they shouldn't receive automatic updates.
-		if !strings.Contains(path, "@") {
-			result.Tag = "latest"
-		}
 	}
 	return result, nil
 }
@@ -133,7 +126,7 @@ func NewImageDependencies(env *BuilderContext, image string, runtime string, bui
 	var dependencies *ImageDependencies
 	if len(image) > 0 {
 		image = env.Expand(image)
-		imageReference, err := NewImageReference(image)
+		imageReference, err := NewImageReference(normalizeImageTag(image))
 		if err != nil {
 			return nil, err
 		}
@@ -147,14 +140,25 @@ func NewImageDependencies(env *BuilderContext, image string, runtime string, bui
 		}
 	}
 
-	runtimeDep, err := NewImageReference(env.Expand(runtime))
+	runtimeDep, err := NewImageReference(normalizeImageTag(env.Expand(runtime)))
 	if err != nil {
 		return nil, err
 	}
 	dependencies.Runtime = runtimeDep
 
+	dict := map[string]bool{}
 	for _, buildtime := range buildtimes {
-		buildtimeDep, err := NewImageReference(env.Expand(buildtime))
+		bt := normalizeImageTag(env.Expand(buildtime))
+
+		// If we've already processed the tag after normalization, skip dependency
+		// generation. I.e., they specify "golang" and "golang:latest"
+		if dict[bt] {
+			continue
+		}
+
+		dict[bt] = true
+
+		buildtimeDep, err := NewImageReference(bt)
 		if err != nil {
 			return nil, err
 		}
@@ -176,4 +180,13 @@ func NewImageDependencies(env *BuilderContext, image string, runtime string, bui
 // DockerCredential denote how to authenticate to a docker registry
 type DockerCredential interface {
 	Authenticate(runner Runner) error
+}
+
+// normalizeImageTag adds "latest" to the image if the specified image
+// has no tag and it's not referenced by digest.
+func normalizeImageTag(img string) string {
+	if !strings.Contains(img, "@") && !strings.Contains(img, ":") {
+		return fmt.Sprintf("%s:latest", img)
+	}
+	return img
 }

--- a/pkg/build.go
+++ b/pkg/build.go
@@ -105,9 +105,8 @@ func NewImageReference(path string) (*ImageReference, error) {
 		result.Tag = tagged.Tag()
 	} else {
 		// Append the "latest" Tag if the path doesn't have a tag AND
-		// it isn't a manifest. E.g., the path is "golang"
-		// In this case we don't want the user to receive automatic
-		// updates since they've specified an absolute digest.
+		// it isn't a manifest. E.g., the path is "golang".
+		// If the user specified a digest they shouldn't receive automatic updates.
 		if !strings.Contains(path, "@") {
 			result.Tag = "latest"
 		}


### PR DESCRIPTION
**Purpose of the PR:**

Always use `latest` as the tag in the dependency output **unless** the path is a digest.

**Example Dockerfile**:

```
FROM hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77
FROM golang:latest as blah
FROM golang as build
FROM docker:17.12.0-ce-git
```


**Example command**:

```
acr-builder -push --docker-registry ehotinger.azurecr.io -t "eric" -t "tests" -t "things"
```

**Output**


```
[
    {
        "image": {
            "registry": "ehotinger.azurecr.io",
            "repository": "eric",
            "tag": "latest",
            "digest": "sha256:271ce7ba399c8483fe085dfdf05003fa5dae0a781f8fbf98e481e62558f1c111"
        },
        "runtime-dependency": {
            "registry": "registry.hub.docker.com",
            "repository": "docker",
            "tag": "17.12.0-ce-git",
            "digest": "sha256:14d3f9d0781478fb34802a197666dd7be5df0ffce46be2bd1dc2f0d814cfdcc9"
        },
        "buildtime-dependency": [
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "hello-world",
                "digest": "sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77"
            }
        ]
    },
    {
        "image": {
            "registry": "ehotinger.azurecr.io",
            "repository": "tests",
            "tag": "latest",
            "digest": "sha256:271ce7ba399c8483fe085dfdf05003fa5dae0a781f8fbf98e481e62558f1c111"
        },
        "runtime-dependency": {
            "registry": "registry.hub.docker.com",
            "repository": "docker",
            "tag": "17.12.0-ce-git",
            "digest": "sha256:14d3f9d0781478fb34802a197666dd7be5df0ffce46be2bd1dc2f0d814cfdcc9"
        },
        "buildtime-dependency": [
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "hello-world",
                "digest": "sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77"
            }
        ]
    },
    {
        "image": {
            "registry": "ehotinger.azurecr.io",
            "repository": "things",
            "tag": "latest",
            "digest": "sha256:271ce7ba399c8483fe085dfdf05003fa5dae0a781f8fbf98e481e62558f1c111"
        },
        "runtime-dependency": {
            "registry": "registry.hub.docker.com",
            "repository": "docker",
            "tag": "17.12.0-ce-git",
            "digest": "sha256:14d3f9d0781478fb34802a197666dd7be5df0ffce46be2bd1dc2f0d814cfdcc9"
        },
        "buildtime-dependency": [
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "hello-world",
                "digest": "sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77"
            }
        ]
    }
]
```