### PR TITLE
Don't query digests if the base image is scratch

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -205,6 +205,14 @@ func PopulateDigests(runner build.Runner, dependencies []build.ImageDependencies
 func queryDigest(runner build.Runner, reference *build.ImageReference) error {
 	if reference != nil {
 		refString := reference.String()
+
+		// refString will always have the tag specified at this point.
+		// For "scratch", we have to compare it against "scratch:latest" even though
+		// scratch:latest isn't valid in a FROM clause.
+		if refString == build.NormalizeImageTag(constants.NoBaseImageSpecifier) {
+			return nil
+		}
+
 		output, err := runner.QueryCmd("docker", []string{
 			"inspect", "--format", "\"{{json .RepoDigests}}\"", refString,
 		})

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -209,7 +209,7 @@ func queryDigest(runner build.Runner, reference *build.ImageReference) error {
 		// refString will always have the tag specified at this point.
 		// For "scratch", we have to compare it against "scratch:latest" even though
 		// scratch:latest isn't valid in a FROM clause.
-		if refString == build.NormalizeImageTag(constants.NoBaseImageSpecifier) {
+		if refString == constants.NoBaseImageSpecifierLatest {
 			return nil
 		}
 

--- a/pkg/constants/etc.go
+++ b/pkg/constants/etc.go
@@ -27,7 +27,9 @@ const (
 	// DependencyTypeRuntime denotes runtime dependency
 	DependencyTypeRuntime = "runtime"
 
-	// NoBaseImageSpecifier is the symbol used by the FROM
+	// NoBaseImageSpecifierLatest is the symbol used by the FROM
 	// command to specify that no base image is to be used.
-	NoBaseImageSpecifier = "scratch"
+	// Note that :latest is not valid in the FROM clause, but we're
+	// always appending :latest to tags during processing.
+	NoBaseImageSpecifierLatest = "scratch:latest"
 )

--- a/pkg/constants/etc.go
+++ b/pkg/constants/etc.go
@@ -26,4 +26,8 @@ const (
 
 	// DependencyTypeRuntime denotes runtime dependency
 	DependencyTypeRuntime = "runtime"
+
+	// NoBaseImageSpecifier is the symbol used by the FROM
+	// command to specify that no base image is to be used.
+	NoBaseImageSpecifier = "scratch"
 )


### PR DESCRIPTION
**Purpose of the PR:**

Don't query digests if the base image is `scratch`.

**Fixes #99**


**Notes/Details:**

```
[
    {
        "image": {
            "registry": "ehotinger.azurecr.io",
            "repository": "eric",
            "tag": "latest",
            "digest": "sha256:d096e3a5ec1792e0c1ca84097694e9c08535797b643c404a7150c7a42232a523"
        },
        "runtime-dependency": {
            "registry": "registry.hub.docker.com",
            "repository": "scratch",
            "tag": "latest",
            "digest": ""
        },
        "buildtime-dependency": null
    }
]
```
