### PR TITLE
Add library to the fully qualified URI of Docker Hub images

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -241,9 +241,16 @@ func getRepoDigest(jsonContent string, reference *build.ImageReference) string {
 	// Output: <empty>
 
 	prefix := reference.Repository + "@"
+	// If the reference has "library/" prefixed, we have to remove it - otherwise
+	// we'll fail to query the digest, since image names aren't prefixed with "library/"
+	if strings.HasPrefix(prefix, "library/") && reference.Registry == build.DockerHubRegistry {
+		prefix = prefix[8:]
+	}
+
 	if len(reference.Registry) > 0 && reference.Registry != build.DockerHubRegistry {
 		prefix = reference.Registry + "/" + prefix
 	}
+
 	var digestList []string
 	if err := json.Unmarshal([]byte(jsonContent), &digestList); err != nil {
 		logrus.Warnf("Error deserialize %s to json, error: %s", jsonContent, err)

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -245,9 +245,7 @@ func getRepoDigest(jsonContent string, reference *build.ImageReference) string {
 	// we'll fail to query the digest, since image names aren't prefixed with "library/"
 	if strings.HasPrefix(prefix, "library/") && reference.Registry == build.DockerHubRegistry {
 		prefix = prefix[8:]
-	}
-
-	if len(reference.Registry) > 0 && reference.Registry != build.DockerHubRegistry {
+	} else if len(reference.Registry) > 0 && reference.Registry != build.DockerHubRegistry {
 		prefix = reference.Registry + "/" + prefix
 	}
 

--- a/tests/resources/dockerfile-dups/ReductionDockerfile
+++ b/tests/resources/dockerfile-dups/ReductionDockerfile
@@ -1,0 +1,14 @@
+FROM alpine
+FROM library/alpine
+FROM alpine:latest
+FROM library/alpine:latest
+
+FROM library/golang
+FROM golang
+FROM library/golang:latest
+FROM golang:latest
+
+FROM ubuntu:latest
+FROM ubuntu
+FROM library/ubuntu
+FROM library/ubuntu:latest


### PR DESCRIPTION
**Purpose of the PR:**

Adds some additional logic to #102 to fully support the fully qualified URI on Docker Hub images and de-duplicating some `FROM` statements.

**Command**:
```
acr-builder -push -docker-file tests/resources/dockerfile-dups/ReductionDockerfile -t "library/eric:foo" -docker-registry ehotinger.azurecr.io
```

**Example Dockerfile**:

```
FROM alpine
FROM library/alpine
FROM alpine:latest
FROM library/alpine:latest

FROM library/golang
FROM golang
FROM library/golang:latest
FROM golang:latest

FROM ubuntu:latest
FROM ubuntu
FROM library/ubuntu
FROM library/ubuntu:latest
```

**Output:**

```
[
    {
        "image": {
            "registry": "ehotinger.azurecr.io",
            "repository": "library/eric",
            "tag": "foo",
            "digest": "sha256:92c414f2cf966fd4c6d60bc71180737bf878eeca3654cad82991a1e02d885d37"
        },
        "runtime-dependency": {
            "registry": "registry.hub.docker.com",
            "repository": "library/ubuntu",
            "tag": "latest",
            "digest": "sha256:9ee3b83bcaa383e5e3b657f042f4034c92cdd50c03f73166c145c9ceaea9ba7c"
        },
        "buildtime-dependency": [
            {
                "registry": "registry.hub.docker.com",
                "repository": "library/alpine",
                "tag": "latest",
                "digest": "sha256:7b848083f93822dd21b0a2f14a110bd99f6efb4b838d499df6d04a49d0debf8b"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "library/golang",
                "tag": "latest",
                "digest": "sha256:024beba2e5a25b36b9dba9e6f0df3cee6c24734a98e77d4f382634e7d9a042c4"
            },
            {
                "registry": "registry.hub.docker.com",
                "repository": "library/ubuntu",
                "tag": "latest",
                "digest": "sha256:9ee3b83bcaa383e5e3b657f042f4034c92cdd50c03f73166c145c9ceaea9ba7c"
            }
        ]
    }
]
```

**Fixes #112**

@Azure/azure-container-registry