### PR TITLE
Don't prefix registry names if image names already have them as prefixes

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -60,7 +60,15 @@ func NewDockerBuild(dockerfile, contextDir string,
 	// If imageName is empty, skip push.
 	// If registry is empty, it means push to DockerHub.
 	for _, imageName := range imageNames {
-		pushTo = append(pushTo, fmt.Sprintf("%s%s", registry, imageName))
+		pushTarget := imageName
+
+		// If the registry's specified and the image name is already prefixed with
+		// the registry's name, don't prefix the registry name again.
+		if registry != "" && !strings.HasPrefix(imageName, registry) {
+			pushTarget = fmt.Sprintf("%s%s", registry, imageName)
+		}
+
+		pushTo = append(pushTo, pushTarget)
 	}
 
 	return &dockerBuildTask{

--- a/pkg/commands/docker_test.go
+++ b/pkg/commands/docker_test.go
@@ -147,6 +147,19 @@ func TestDockerPushHappy(t *testing.T) {
 	})
 }
 
+// TestDockerPushHappy_AvoidDuplicatePrefixes verifies that we don't
+// prefix an image name with the registry name if it already has it as a prefix.
+func TestDockerPushHappy_AvoidDuplicatePrefixes(t *testing.T) {
+	testDockerPush(t, dockerTestCase{
+		registry:   "myRegistry/",
+		imageNames: []string{"myRegistry/myImage"},
+		expectedCommands: []test.CommandsExpectation{{
+			Command: "docker",
+			Args:    []string{"push", "myRegistry/myImage"},
+		}},
+	})
+}
+
 type dockerDependenciesTestCase struct {
 	path        string
 	expectedErr string


### PR DESCRIPTION
**Purpose of the PR:**

Don't prefix the registry name to image names if the image name already has the registry name prefixed. 

I.e., 
```
acr-builder -push -docker-file tests/resources/dockerfile-dups/ReductionDockerfile -t "ericrepo/eric:foo" -docker-registry ehotinger.azurecr.io -t "ehotinger.azurecr.io/eric:foo" -t "ehotinger.azurecr.io/foo" -t "blah"
```

Should not prefix `ehotinger.azurecr.io` to `ehotinger.azurecr.io/eric` or `ehotinger.azurecr.io/foo`.

**Fixes #111**

@Azure/azure-container-registry