### PR TITLE
Ignore unhandled error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 install:
   - go get github.com/golang/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck
+  - go get github.com/kisielk/errcheck
   
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GO_LDFLAGS_STATIC=-ldflags "-w $(CTIMEVAR) -extldflags -static"
 # List the GOOS and GOARCH to build
 GOOSARCHES = linux/amd64
 
-all: clean build fmt lint test staticcheck vet
+all: clean build fmt lint test staticcheck vet errcheck
 
 cbuild: clean build ## Runs a clean and a build
 
@@ -48,6 +48,11 @@ static: ## Builds a static executable
 fmt: ## Verifies `gofmt` passes
 	@echo "+ $@"
 	@gofmt -s -l . | grep -v '.pb.go:' | grep -v vendor | tee /dev/stderr
+
+.PHONY: errcheck
+errcheck: ## Verifies `errcheck` passes
+	@echo "+ $@"
+	@errcheck ./... | grep -v vendor | tee /dev/stderr
 
 .PHONY: lint
 lint: ## Verifies `golint` passes

--- a/tests/testCommon/file_server.go
+++ b/tests/testCommon/file_server.go
@@ -33,7 +33,7 @@ func StartStaticFileServer(t *testing.T, handler http.Handler) *http.Server {
 		for !started && retryCount < startRetryN {
 			err := server.ListenAndServe()
 			if err != nil && err != http.ErrServerClosed {
-				fmt.Fprintf(os.Stderr, "Failed to start server: %s\n", err)
+				_, _ = fmt.Fprintf(os.Stderr, "Failed to start server: %s\n", err)
 				time.Sleep(startRetryInterval)
 				retryCount++
 			} else {


### PR DESCRIPTION
Fixes #122 by ignoring an unhandled error. Adds errcheck to the `Makefile` and Travis so that this error can't make it in past PRs.