### PR TITLE
Remove build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ Run the following on your project directory to build the project and push to a d
 * `--verbose` Enable verbose output for debugging.
 
 ### Build Environment
-You can set an environment variable with `--build-env <VAR_NAME>=<VAR_VALUE>` and the builder will be aware of an environment variable throughout the build (the same goes for all child processes). ACR builder has a set of reserved environment variables such as `ACR_BUILD_BUILD_NUMBER` and `ACR_BUILD_DOCKER_REGISTRY` mentioned in the parameters paragraph. You can set them by passing in the optional parameters `--build-number` and `--docker-registry` and they can't be overridden with `--build-env`.
+You can set an environment variable with `--build-env <VAR_NAME>=<VAR_VALUE>` and the builder will be aware of an environment variable throughout the build (the same goes for all child processes). ACR builder has a set of reserved environment variables such as `ACR_BUILD_DOCKER_REGISTRY` mentioned in the parameters paragraph. You can set them by passing in the optional parameter `--docker-registry` and they can't be overridden with `--build-env`.
 
 Furthermore, ACR builder also populates the following variables during build so the child process can make use of these values:
 
-* `ACR_BUILD_NUMBER` Current build number.
 * `ACR_BUILD_TIMESTAMP` Timestamp of where the build start in ISO format.
 * `ACR_BUILD_PUSH_IMAGES` Indicates whether or not the current build will push on success.

--- a/main.go
+++ b/main.go
@@ -44,8 +44,6 @@ func main() {
 	var dockerUser, dockerPW, dockerRegistry string
 	var buildArgs, buildSecretArgs, buildEnvs stringSlice
 	var pull, noCache, push, debug bool
-	var buildNumber string
-	flag.StringVar(&buildNumber, constants.ArgNameBuildNumber, "0", fmt.Sprintf("Build number, this argument would set the reserved %s build environment.", constants.ExportsBuildNumber))
 	flag.StringVar(&dockerContextString, constants.ArgNameDockerContextString, "", "Working directory for the builder.")
 	flag.StringVar(&dockerfile, constants.ArgNameDockerfile, "", "Dockerfile to build. If choosing to build a dockerfile")
 	flag.Var(&dockerImages, constants.ArgNameDockerImage, "The image names to build to. This option is only available when building with dockerfile")
@@ -86,7 +84,6 @@ func main() {
 	normalizedDockerImages := getNormalizedDockerImageNames(dockerImages)
 
 	dependencies, err := builder.Run(
-		buildNumber,
 		dockerfile, normalizedDockerImages,
 		dockerUser, dockerPW, dockerRegistry,
 		dockerContextString,

--- a/pkg/constants/exports.go
+++ b/pkg/constants/exports.go
@@ -16,9 +16,6 @@ const (
 	// ExportsPushOnSuccess is the boolean value denoting whether the build will push on success
 	ExportsPushOnSuccess = acrBuildPrefix + "PUSH_ON_SUCCESS"
 
-	// ExportsBuildNumber is the current build number
-	ExportsBuildNumber = acrBuildPrefix + "NUMBER"
-
 	// ExportsBuildTimestamp is the timestamp when the build started in ISO format
 	ExportsBuildTimestamp = acrBuildPrefix + "TIMESTAMP"
 )

--- a/pkg/constants/program_args.go
+++ b/pkg/constants/program_args.go
@@ -1,8 +1,6 @@
 package constants
 
 const (
-	// ArgNameBuildNumber is the parameter name for build number
-	ArgNameBuildNumber = "build-number"
 
 	//ArgNameDockerContextString is the parameter name docker build context, it could be local path, git, or archive url
 	ArgNameDockerContextString = "c"

--- a/pkg/driver/build.go
+++ b/pkg/driver/build.go
@@ -26,7 +26,7 @@ func NewBuilder(runner build.Runner) *Builder {
 }
 
 // Run is the main body of the acr-builder
-func (b *Builder) Run(buildNumber string,
+func (b *Builder) Run(
 	dockerfile string, dockerImages []string,
 	dockerUser, dockerPW, dockerRegistry,
 	dockerContextString string,
@@ -54,7 +54,7 @@ func (b *Builder) Run(buildNumber string,
 		return
 	}
 
-	buildWorkflow := compileWorkflow(buildNumber, userDefined, request, push)
+	buildWorkflow := compileWorkflow(userDefined, request, push)
 	err = buildWorkflow.Run(b.runner)
 	if err == nil {
 		dependencies = buildWorkflow.GetOutputs().ImageDependencies
@@ -160,13 +160,11 @@ type evaluationTaskItem struct {
 }
 
 // compileWorkflow takes a build request and populate it into workflow
-func compileWorkflow(buildNumber string,
-	userDefined []build.EnvVar, request *build.Request, push bool) *workflow.Workflow {
+func compileWorkflow(userDefined []build.EnvVar, request *build.Request, push bool) *workflow.Workflow {
 
 	// create a workflow with root context with default variables
 	w := workflow.NewWorkflow()
 	rootContext := build.NewContext(userDefined, []build.EnvVar{
-		{Name: constants.ExportsBuildNumber, Value: buildNumber},
 		{Name: constants.ExportsBuildTimestamp, Value: time.Now().UTC().Format(constants.TimestampFormat)},
 		{Name: constants.ExportsDockerRegistry, Value: request.DockerRegistry},
 		{Name: constants.ExportsPushOnSuccess, Value: strconv.FormatBool(push)}})

--- a/pkg/driver/build_test.go
+++ b/pkg/driver/build_test.go
@@ -113,7 +113,6 @@ type dockerCredsParameters struct {
 }
 
 type compileTestCase struct {
-	buildNumber          string
 	registry             string
 	userDefined          []build.EnvVar
 	creds                []dockerCredsParameters
@@ -126,15 +125,13 @@ type compileTestCase struct {
 func newMultiSourceTestCase(push bool) *compileTestCase {
 	gen := testCommon.NewMappedGenerator("value")
 	return &compileTestCase{
-		buildNumber: "TestCompileHappy-01",
-		registry:    "TestCompileHappy.azurecr.io",
+		registry: "TestCompileHappy.azurecr.io",
 		userDefined: []build.EnvVar{
 			{Name: "k1", Value: gen.NextWithKey("k1")},
 			{Name: "k2", Value: gen.NextWithKey("k2")},
 		},
 		creds: []dockerCredsParameters{
 			{expectedEnv: []string{
-				constants.ExportsBuildNumber + "=TestCompileHappy-01",
 				constants.ExportsDockerRegistry + "=TestCompileHappy.azurecr.io",
 				constants.ExportsPushOnSuccess + "=" + strconv.FormatBool(push),
 				"k1=" + gen.Lookup("k1"),
@@ -149,7 +146,6 @@ func newMultiSourceTestCase(push bool) *compileTestCase {
 					{Name: "s1.2", Value: gen.NextWithKey("s1.2")},
 				},
 				expectedEnv: []string{
-					constants.ExportsBuildNumber + "=TestCompileHappy-01",
 					constants.ExportsDockerRegistry + "=TestCompileHappy.azurecr.io",
 					constants.ExportsPushOnSuccess + "=" + strconv.FormatBool(push),
 					"k1=" + gen.Lookup("k1"),
@@ -164,7 +160,6 @@ func newMultiSourceTestCase(push bool) *compileTestCase {
 							{Name: "b1.1.2", Value: gen.NextWithKey("b1.1.2")},
 						},
 						expectedEnv: []string{
-							constants.ExportsBuildNumber + "=TestCompileHappy-01",
 							constants.ExportsDockerRegistry + "=TestCompileHappy.azurecr.io",
 							constants.ExportsPushOnSuccess + "=" + strconv.FormatBool(push),
 							"k1=" + gen.Lookup("k1"),
@@ -181,7 +176,6 @@ func newMultiSourceTestCase(push bool) *compileTestCase {
 							{Name: "b1.2.2", Value: gen.NextWithKey("b1.2.2")},
 						},
 						expectedEnv: []string{
-							constants.ExportsBuildNumber + "=TestCompileHappy-01",
 							constants.ExportsDockerRegistry + "=TestCompileHappy.azurecr.io",
 							constants.ExportsPushOnSuccess + "=" + strconv.FormatBool(push),
 							"k1=" + gen.Lookup("k1"),
@@ -200,7 +194,6 @@ func newMultiSourceTestCase(push bool) *compileTestCase {
 					{Name: "s2.2", Value: gen.NextWithKey("s2.2")},
 				},
 				expectedEnv: []string{
-					constants.ExportsBuildNumber + "=TestCompileHappy-01",
 					constants.ExportsDockerRegistry + "=TestCompileHappy.azurecr.io",
 					constants.ExportsPushOnSuccess + "=" + strconv.FormatBool(push),
 					"k1=" + gen.Lookup("k1"),
@@ -215,7 +208,6 @@ func newMultiSourceTestCase(push bool) *compileTestCase {
 							{Name: "b2.1.2", Value: gen.NextWithKey("b2.1.2")},
 						},
 						expectedEnv: []string{
-							constants.ExportsBuildNumber + "=TestCompileHappy-01",
 							constants.ExportsDockerRegistry + "=TestCompileHappy.azurecr.io",
 							constants.ExportsPushOnSuccess + "=" + strconv.FormatBool(push),
 							"k1=" + gen.Lookup("k1"),
@@ -285,7 +277,7 @@ func testCompile(t *testing.T, tc *compileTestCase) {
 		req.Targets = append(req.Targets, target)
 	}
 	runner.PrepareDigestQuery(tc.expectedDependencies, tc.queryCmdErr)
-	workflow := compileWorkflow(tc.buildNumber, tc.userDefined, req, tc.push)
+	workflow := compileWorkflow(tc.userDefined, req, tc.push)
 	err := workflow.Run(runner)
 	assert.Nil(t, err)
 	outputs := workflow.GetOutputs()
@@ -495,7 +487,6 @@ func testCreateBuildRequest(t *testing.T, tc createBuildRequestTestCase) {
 }
 
 type runTestCase struct {
-	buildNumber          string
 	dockerfile           string
 	dockerImages         []string
 	dockerUser           string
@@ -516,7 +507,6 @@ type runTestCase struct {
 
 func TestRunSimpleHappy(t *testing.T) {
 	testRun(t, runTestCase{
-		buildNumber:         "buildNum-0",
 		dockerRegistry:      testCommon.TestsDockerRegistryName,
 		dockerImages:        []string{"hello-multistage"},
 		dockerContextString: filepath.Join(testCommon.Config.ProjectRoot, "tests", "resources", "hello-multistage"),
@@ -533,7 +523,6 @@ func TestRunSimpleHappy(t *testing.T) {
 	})
 
 	testRun(t, runTestCase{
-		buildNumber:         "buildNum-1",
 		dockerRegistry:      testCommon.TestsDockerRegistryName,
 		dockerImages:        []string{"hello-node"},
 		dockerfile:          "Dockerfile.alpine",
@@ -553,7 +542,6 @@ func TestRunSimpleHappy(t *testing.T) {
 
 func TestRunPull(t *testing.T) {
 	testRun(t, runTestCase{
-		buildNumber:         "buildNum-0",
 		dockerRegistry:      testCommon.TestsDockerRegistryName,
 		dockerImages:        []string{"hello-multistage"},
 		pull:                true,
@@ -573,7 +561,6 @@ func TestRunPull(t *testing.T) {
 
 func TestRunNoCache(t *testing.T) {
 	testRun(t, runTestCase{
-		buildNumber:         "buildNum-0",
 		dockerRegistry:      testCommon.TestsDockerRegistryName,
 		dockerImages:        []string{"hello-multistage"},
 		noCache:             true,
@@ -593,7 +580,6 @@ func TestRunNoCache(t *testing.T) {
 
 func TestRunNoImageGiven(t *testing.T) {
 	testRun(t, runTestCase{
-		buildNumber:         "buildNum-0",
 		dockerRegistry:      testCommon.TestsDockerRegistryName,
 		dockerContextString: filepath.Join(testCommon.Config.ProjectRoot, "tests", "resources", "hello-multistage"),
 		expectedCommands: []test.CommandsExpectation{
@@ -617,7 +603,6 @@ func TestRunNoImageGiven(t *testing.T) {
 func TestRunNoRegistryGiven(t *testing.T) {
 	os.Clearenv()
 	testRun(t, runTestCase{
-		buildNumber:         "buildNum-0",
 		dockerImages:        []string{"hello-multistage"},
 		dockerContextString: filepath.Join(testCommon.Config.ProjectRoot, "tests", "resources", "hello-multistage"),
 		expectedCommands: []test.CommandsExpectation{
@@ -637,7 +622,6 @@ func TestRunNoRegistryGivenPush(t *testing.T) {
 	os.Clearenv()
 	testRun(t, runTestCase{
 		push:                true,
-		buildNumber:         "buildNum-0",
 		dockerContextString: filepath.Join(testCommon.Config.ProjectRoot, "tests", "resources", "hello-node"),
 		expectedErr: fmt.Sprintf("^Docker registry is needed for push, use --%s or environment variable %s to provide its value$",
 			constants.ArgNameDockerRegistry, constants.ExportsDockerRegistry),
@@ -649,7 +633,6 @@ func TestRunNoImageGivenPush(t *testing.T) {
 	testRun(t, runTestCase{
 		push:                true,
 		dockerRegistry:      "testregistry",
-		buildNumber:         "buildNum-0",
 		dockerContextString: filepath.Join(testCommon.Config.ProjectRoot, "tests", "resources", "hello-node"),
 		expectedErr: fmt.Sprintf("Docker image is needed for push, use --%s to provide its value",
 			constants.ArgNameDockerImage),
@@ -680,7 +663,7 @@ func testRun(t *testing.T, tc runTestCase) {
 	runner.PrepareCommandExpectation(tc.expectedCommands)
 	runner.PrepareDigestQuery(tc.expectedDependencies, tc.queryCmdErr)
 	builder := NewBuilder(runner)
-	dependencies, err := builder.Run(tc.buildNumber,
+	dependencies, err := builder.Run(
 		tc.dockerfile, tc.dockerImages,
 		tc.dockerUser, tc.dockerPW, tc.dockerRegistry,
 		tc.dockerContextString,


### PR DESCRIPTION
**Purpose of the PR:**

Removes the `build-number` export. This functionality is already supported by means of normal build args.