### PR TITLE
set X-Meta-Source-Client header to ACR-BUILDER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,15 @@ RUN echo "Running Static Analysis tools..." &&\
     echo "Verification successful, building binaries..." &&\
     GOOS=linux GOARCH=386 go build
 
-FROM docker:17.12.0-ce-git
+FROM docker:18.03.1-ce-git
 RUN apk add --update --no-cache \
     openssh \
     openssl \
     ca-certificates \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    # Update Docker CLI config and set X-Meta-Source-Client header to ACR-BUILDER
+    && mkdir -p ~/.docker \ 
+    && echo '{"HttpHeaders":{"X-Meta-Source-Client":"ACR-BUILDER"}}' > ~/.docker/config.json
 COPY --from=build /go/src/github.com/Azure/acr-builder/acr-builder /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/acr-builder"]
 CMD []

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -93,7 +93,11 @@ RUN Write-Host ('Running build' ); \
 FROM environment as runtime
 COPY --from=dockercli /gopath/src/github.com/docker/cli/build/docker.exe c:/docker/docker.exe
 COPY --from=builder /gopath/src/github.com/Azure/acr-builder/acr-builder.exe c:/acr-builder/acr-builder.exe
-RUN setx /M PATH $('c:\acr-builder;c:\docker;{0}' -f $env:PATH)
+
+RUN setx /M PATH $('c:\acr-builder;c:\docker;{0}' -f $env:PATH); \
+    # Update Docker CLI config and set X-Meta-Source-Client header to ACR-BUILDER
+	New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\\.docker"; \
+	'{"HttpHeaders":{"X-Meta-Source-Client":"ACR-BUILDER"}}' | Out-File -FilePath "$env:USERPROFILE\\.docker\\config.json"
 
 ENTRYPOINT ["acr-builder.exe"]
 CMD []


### PR DESCRIPTION
**Purpose of the PR:**
Add `X-Meta-Source-Client` http header in Docker CLI config. The header will be passed to the registry when pull/push and allow the registry to track the client source.