### PR TITLE
Update gitignore - ignore exes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,15 +5,14 @@
 *.dylib
 
 acb
+*.exe
+.vscode/
 
 # Test binary, build with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
 
 # temp folder when downloading tars
 temp/


### PR DESCRIPTION
**Purpose of the PR:**

Updates the gitignore to ignore `*.exe` and `.vscode` directories if debugging on Windows. Removes glide because we use `dep` instead.