### PR TITLE
Add default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default owners for everything in the repo
+* @sajayantony @northtyphoon @mnltejaswini @ehotinger


### PR DESCRIPTION
**Purpose of the PR:**

Adds global code owners, these people will automatically be added to all PRs. @mnltejaswini @sajayantony @northtyphoon 