### PR TITLE
Allow parseArgs to take multiple matches for CLI parameters

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -23,6 +23,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var buildArgLookup = map[string]bool{"--build-arg": true}
+var tagLookup = map[string]bool{"-t": true, "--tag": true}
+
 // Builder builds images.
 type Builder struct {
 	cmder        *cmder.Cmder
@@ -165,8 +168,8 @@ func (b *Builder) processVertex(ctx context.Context, dag *graph.Dag, parent *gra
 			// TODO: refactor this out of the node processing into initialization.
 			// Adjust the run command so that the ACR registry is prefixed for all tags
 			step.Run = prefixStepTags(step.Run, b.buildOptions.RegistryName)
-			tags := parseRunArgs(step.Run, "-t")
-			buildArgs := parseRunArgs(step.Run, "--build-arg")
+			tags := parseRunArgs(step.Run, tagLookup)
+			buildArgs := parseRunArgs(step.Run, buildArgLookup)
 			dockerfile, context := parseDockerBuildCmd(step.Run)
 			volName := b.workspaceDir
 

--- a/builder/parse.go
+++ b/builder/parse.go
@@ -11,12 +11,13 @@ import (
 var httpPrefix = regexp.MustCompile("^https?://")
 var gitURLWithSuffix = regexp.MustCompile("\\.git(?:#.+)?$")
 
-func parseRunArgs(runCmd string, match string) []string {
+// parseRunArgs parses the "Run" command of a Step.
+func parseRunArgs(runCmd string, lookup map[string]bool) []string {
 	fields := strings.Fields(runCmd)
 	prevField := ""
 	matches := []string{}
 	for _, field := range fields {
-		if prevField == match {
+		if found := lookup[prevField]; found {
 			matches = append(matches, field)
 		}
 		prevField = field

--- a/builder/parse_test.go
+++ b/builder/parse_test.go
@@ -3,7 +3,34 @@
 
 package builder
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Azure/acr-builder/util"
+)
+
+func TestParseRunArgs(t *testing.T) {
+	tests := []struct {
+		id       int
+		cmd      string
+		lookup   map[string]bool
+		expected []string
+	}{
+		// Tag tests
+		{1, "build -f Dockerfile -t {{.Build.ID}}:latest --tag blah https://github.com/Azure/acr-builder.git", tagLookup, []string{"{{.Build.ID}}:latest", "blah"}},
+		{2, "build --tag foo https://github.com/Azure/acr-builder.git --tag bar -t qux", tagLookup, []string{"foo", "bar", "qux"}},
+
+		// Build arg tests
+		{3, "build -f Dockerfile -t hello:world --build-arg foo https://github.com/Azure/acr-builder.git --build-arg bar", buildArgLookup, []string{"foo", "bar"}},
+	}
+
+	for _, test := range tests {
+		actual := parseRunArgs(test.cmd, test.lookup)
+		if !util.StringSequenceEquals(actual, test.expected) {
+			t.Errorf("Test %d failed. Expected %v, got %v", test.id, test.expected, actual)
+		}
+	}
+}
 
 // TestParseDockerBuildCmd tests stripping out the positional Docker context and Dockerfile name from a build command.
 func TestParseDockerBuildCmd(t *testing.T) {

--- a/builder/parse_test.go
+++ b/builder/parse_test.go
@@ -22,6 +22,7 @@ func TestParseRunArgs(t *testing.T) {
 
 		// Build arg tests
 		{3, "build -f Dockerfile -t hello:world --build-arg foo https://github.com/Azure/acr-builder.git --build-arg bar", buildArgLookup, []string{"foo", "bar"}},
+		{4, "build -f Dockerfile -t hello:world --buildarg ignored --build-arg foo=bar https://github.com/Azure/acr-builder.git --build-arg hello=world", buildArgLookup, []string{"foo=bar", "hello=world"}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Purpose of the PR:**

- Allow `parseArgs` to take multiple matches for CLI parameters (in the case of `tag`, it can be `--tag` or `-t`).
- Add tests for `parseArgs`