### PR TITLE
- Adds initial templating support for `build`

### DIFF
--- a/builder/build_options.go
+++ b/builder/build_options.go
@@ -9,6 +9,4 @@ type BuildOptions struct {
 	RegistryUsername string
 	RegistryPassword string
 	Push             bool
-	NoCache          bool
-	Pull             bool
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -23,8 +23,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var buildArgLookup = map[string]bool{"--build-arg": true}
-var tagLookup = map[string]bool{"-t": true, "--tag": true}
+// BuildArgLookup defines string matches for build args.
+var BuildArgLookup = map[string]bool{"--build-arg": true}
+
+// TagLookup defines string matches for tags.
+var TagLookup = map[string]bool{"-t": true, "--tag": true}
 
 // Builder builds images.
 type Builder struct {
@@ -168,8 +171,8 @@ func (b *Builder) processVertex(ctx context.Context, dag *graph.Dag, parent *gra
 			// TODO: refactor this out of the node processing into initialization.
 			// Adjust the run command so that the ACR registry is prefixed for all tags
 			step.Run = prefixStepTags(step.Run, b.buildOptions.RegistryName)
-			tags := parseRunArgs(step.Run, tagLookup)
-			buildArgs := parseRunArgs(step.Run, buildArgLookup)
+			tags := ParseRunArgs(step.Run, TagLookup)
+			buildArgs := ParseRunArgs(step.Run, BuildArgLookup)
 			dockerfile, context := parseDockerBuildCmd(step.Run)
 			volName := b.workspaceDir
 

--- a/builder/parse.go
+++ b/builder/parse.go
@@ -11,8 +11,8 @@ import (
 var httpPrefix = regexp.MustCompile("^https?://")
 var gitURLWithSuffix = regexp.MustCompile("\\.git(?:#.+)?$")
 
-// parseRunArgs parses the "Run" command of a Step.
-func parseRunArgs(runCmd string, lookup map[string]bool) []string {
+// ParseRunArgs parses the "Run" command of a Step.
+func ParseRunArgs(runCmd string, lookup map[string]bool) []string {
 	fields := strings.Fields(runCmd)
 	prevField := ""
 	matches := []string{}

--- a/builder/parse_test.go
+++ b/builder/parse_test.go
@@ -17,16 +17,16 @@ func TestParseRunArgs(t *testing.T) {
 		expected []string
 	}{
 		// Tag tests
-		{1, "build -f Dockerfile -t {{.Build.ID}}:latest --tag blah https://github.com/Azure/acr-builder.git", tagLookup, []string{"{{.Build.ID}}:latest", "blah"}},
-		{2, "build --tag foo https://github.com/Azure/acr-builder.git --tag bar -t qux", tagLookup, []string{"foo", "bar", "qux"}},
+		{1, "build -f Dockerfile -t {{.Build.ID}}:latest --tag blah https://github.com/Azure/acr-builder.git", TagLookup, []string{"{{.Build.ID}}:latest", "blah"}},
+		{2, "build --tag foo https://github.com/Azure/acr-builder.git --tag bar -t qux", TagLookup, []string{"foo", "bar", "qux"}},
 
 		// Build arg tests
-		{3, "build -f Dockerfile -t hello:world --build-arg foo https://github.com/Azure/acr-builder.git --build-arg bar", buildArgLookup, []string{"foo", "bar"}},
-		{4, "build -f Dockerfile -t hello:world --buildarg ignored --build-arg foo=bar https://github.com/Azure/acr-builder.git --build-arg hello=world", buildArgLookup, []string{"foo=bar", "hello=world"}},
+		{3, "build -f Dockerfile -t hello:world --build-arg foo https://github.com/Azure/acr-builder.git --build-arg bar", BuildArgLookup, []string{"foo", "bar"}},
+		{4, "build -f Dockerfile -t hello:world --buildarg ignored --build-arg foo=bar https://github.com/Azure/acr-builder.git --build-arg hello=world", BuildArgLookup, []string{"foo=bar", "hello=world"}},
 	}
 
 	for _, test := range tests {
-		actual := parseRunArgs(test.cmd, test.lookup)
+		actual := ParseRunArgs(test.cmd, test.lookup)
 		if !util.StringSequenceEquals(actual, test.expected) {
 			t.Errorf("Test %d failed. Expected %v, got %v", test.id, test.expected, actual)
 		}

--- a/cli/render.go
+++ b/cli/render.go
@@ -34,17 +34,22 @@ func newRenderCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	AddBaseRenderingOptions(f, r.opts, cmd)
+	AddBaseRenderingOptions(f, r.opts, cmd, true)
 	return cmd
 }
 
 func (r *renderCmd) run(cmd *cobra.Command, args []string) error {
-	template, err := templating.LoadAndRenderSteps(r.opts)
+	template, err := templating.LoadTemplate(r.opts.StepsFile)
+	if err != nil {
+		return err
+	}
+
+	rendered, err := templating.LoadAndRenderSteps(template, r.opts)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Rendered template:")
-	fmt.Println(template)
+	fmt.Println(rendered)
 	return nil
 }

--- a/cli/shared.go
+++ b/cli/shared.go
@@ -12,22 +12,23 @@ import (
 
 // AddBaseRenderingOptions adds base rendering options to the specified flagset and maps the flags
 // to the options struct.
-func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions, cmd *cobra.Command) {
+func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions, cmd *cobra.Command, usesSteps bool) {
 
 	// Templates & values files
 	f.StringVar(&opts.ValuesFile, "values", "", "the values file to use")
-	f.StringVar(&opts.StepsFile, "steps", "", "the steps file to use")
 	f.StringArrayVar(&opts.TemplateValues, "set", []string{}, "set values on the command line (use `--set` multiple times or use commas: key1=val1,key2=val2)")
 
 	// Base rendering options
 	f.StringVar(&opts.ID, "id", "", "the build ID")
 	f.StringVarP(&opts.Commit, "commit", "c", "", "the commit SHA")
-	f.StringVarP(&opts.Tag, "tag", "t", "", "the build tag")
 	f.StringVar(&opts.Repository, "repository", "", "the build repository")
 	f.StringVarP(&opts.Branch, "branch", "b", "", "the build branch")
 	f.StringVar(&opts.TriggeredBy, "triggered-by", "", "what the build was triggered by")
 	f.StringVarP(&opts.Registry, "registry", "r", "", "the name of the registry")
 
-	// Required flags
-	_ = cmd.MarkFlagRequired("steps")
+	// exec and render both use steps and it's required, but build doesn't
+	if usesSteps {
+		f.StringVar(&opts.StepsFile, "steps", "", "the steps file to use")
+		_ = cmd.MarkFlagRequired("steps")
+	}
 }

--- a/cli/shared.go
+++ b/cli/shared.go
@@ -24,6 +24,7 @@ func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions
 	f.StringVar(&opts.Repository, "repository", "", "the build repository")
 	f.StringVarP(&opts.Branch, "branch", "b", "", "the build branch")
 	f.StringVar(&opts.TriggeredBy, "triggered-by", "", "what the build was triggered by")
+	f.StringVar(&opts.GitTag, "git-tag", "", "the git tag")
 	f.StringVarP(&opts.Registry, "registry", "r", "", "the name of the registry")
 
 	// exec and render both use steps and it's required, but build doesn't

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -34,6 +34,9 @@ type BaseRenderOptions struct {
 	// TriggeredBy is the reason the build was triggered. Required.
 	TriggeredBy string
 
+	// GitTag is a Git tag. Optional.
+	GitTag string
+
 	// Registry is the ACR being used. Optional.
 	Registry string
 }
@@ -46,6 +49,7 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, options *BaseRenderOpti
 			"Commit":      options.Commit,
 			"Repository":  options.Repository,
 			"Branch":      options.Branch,
+			"GitTag":      options.GitTag,
 			"TriggeredBy": options.TriggeredBy,
 			"Registry":    options.Registry,
 		},

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -25,9 +25,6 @@ type BaseRenderOptions struct {
 	// Commit is the commit used when running the build. Optional.
 	Commit string
 
-	// Tag is the tag used when running the build. Optional.
-	Tag string
-
 	// Repository is the repository used when running the build. Optional.
 	Repository string
 
@@ -47,7 +44,6 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, options *BaseRenderOpti
 		"Build": map[string]interface{}{
 			"ID":          options.ID,
 			"Commit":      options.Commit,
-			"Tag":         options.Tag,
 			"Repository":  options.Repository,
 			"Branch":      options.Branch,
 			"TriggeredBy": options.TriggeredBy,
@@ -66,11 +62,8 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, options *BaseRenderOpti
 
 // LoadAndRenderSteps loads a template file and renders it according to an optional values file, --set values,
 // and base render options.
-func LoadAndRenderSteps(opts *BaseRenderOptions) (string, error) {
-	template, err := LoadTemplate(opts.StepsFile)
-	if err != nil {
-		return "", err
-	}
+func LoadAndRenderSteps(template *Template, opts *BaseRenderOptions) (string, error) {
+	var err error
 
 	config := &Config{}
 	if opts.ValuesFile != "" {
@@ -100,7 +93,7 @@ func LoadAndRenderSteps(opts *BaseRenderOptions) (string, error) {
 		return "", fmt.Errorf("Error while rendering templates: %v", err)
 	}
 
-	return rendered[opts.StepsFile], nil
+	return rendered[template.Name], nil
 }
 
 func combineVals(values []string) (string, error) {

--- a/templating/engine.go
+++ b/templating/engine.go
@@ -70,7 +70,7 @@ func (e *Engine) render(templates map[string]renderableTemplate) (rendered map[s
 		t.Option("missingkey=zero")
 	}
 
-	// Gather all the templates from the job's files.
+	// Gather all the template filenames.
 	files := []string{}
 
 	// Sort the templates for consistent ordering

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -115,7 +115,6 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 
 	expectedID := "SomeID"
 	expectedCommit := "Some Commit"
-	expectedTag := "some Tag"
 	expectedRepo := "some RePo"
 	expectedBranch := "br"
 	expectedTrigger := "triggered from someone cool!!1"
@@ -124,7 +123,6 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	options := &BaseRenderOptions{
 		ID:          expectedID,
 		Commit:      expectedCommit,
-		Tag:         expectedTag,
 		Repository:  expectedRepo,
 		Branch:      expectedBranch,
 		TriggeredBy: expectedTrigger,
@@ -139,7 +137,6 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		// Base properties
 		{"{{.Build.ID}}", expectedID},
 		{"{{.Build.Commit}}", expectedCommit},
-		{"{{ .Build.Tag }}", expectedTag},
 		{"{{ .Build.Repository}}", expectedRepo},
 		{"{{.Build.Branch}}", expectedBranch},
 		{"{{.Build.TriggeredBy}}", expectedTrigger},

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -119,6 +119,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	expectedBranch := "br"
 	expectedTrigger := "triggered from someone cool!!1"
 	expectedRegistry := "foo.azurecr.io"
+	expectedGitTag := "some git tag"
 
 	options := &BaseRenderOptions{
 		ID:          expectedID,
@@ -127,6 +128,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		Branch:      expectedBranch,
 		TriggeredBy: expectedTrigger,
 		Registry:    expectedRegistry,
+		GitTag:      expectedGitTag,
 	}
 	vals, err := OverrideValuesWithBuildInfo(c1, c2, options)
 	if err != nil {
@@ -141,6 +143,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Build.Branch}}", expectedBranch},
 		{"{{.Build.TriggeredBy}}", expectedTrigger},
 		{"{{.Build.Registry}}", expectedRegistry},
+		{"{{.Build.GitTag}}", expectedGitTag},
 		{"{{.Values.born}}", eCurieBorn},
 		{"{{.Values.first}}", eCurieFirst},
 		{"{{.Values.last}}", eCurieLast},


### PR DESCRIPTION
**Purpose of the PR:**

- Adds initial templating support for `build`
- Fixes a bug in `build` where `--pull` wasn't being set
- Removes `{{.Build.Tag}}` for now since it conflicts with `--tag` on `build` (and I'm not sure of its use case still)

```bash
$ acb build https://github.com/Azure/acr-builder.git -f Dockerfile -t "acr-builder:{{.Build.ID}}" -t 'acr-builder:{{now | date "20060102"}}' --id demo

...

Successfully tagged acr-builder:demo
Successfully tagged acr-builder:20180709
```

**Fixes #139**