### PR TITLE
First class .Build.Date

### DIFF
--- a/cli/shared.go
+++ b/cli/shared.go
@@ -4,6 +4,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 
@@ -26,6 +28,8 @@ func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions
 	f.StringVar(&opts.TriggeredBy, "triggered-by", "", "what the build was triggered by")
 	f.StringVar(&opts.GitTag, "git-tag", "", "the git tag")
 	f.StringVarP(&opts.Registry, "registry", "r", "", "the name of the registry")
+
+	opts.Date = time.Now().UTC()
 
 	// exec and render both use steps and it's required, but build doesn't
 	if usesSteps {

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -6,6 +6,7 @@ package templating
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // BaseRenderOptions represents additional information for the composition of the final rendering.
@@ -39,6 +40,9 @@ type BaseRenderOptions struct {
 
 	// Registry is the ACR being used. Optional.
 	Registry string
+
+	// Date is the date of the Build. Required.
+	Date time.Time
 }
 
 // OverrideValuesWithBuildInfo overrides the specified config's values and provides a default set of values.
@@ -52,6 +56,7 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, options *BaseRenderOpti
 			"GitTag":      options.GitTag,
 			"TriggeredBy": options.TriggeredBy,
 			"Registry":    options.Registry,
+			"Date":        options.Date.Format("20060102-150405z"), // yyyyMMdd-HHmmssz
 		},
 	}
 

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"testing"
 	"text/template"
+	"time"
 )
 
 const (
@@ -121,6 +122,13 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	expectedRegistry := "foo.azurecr.io"
 	expectedGitTag := "some git tag"
 
+	parsedTime, err := time.Parse("20060102-150405", "20100520-131422")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTime := "20100520-131422z"
+
 	options := &BaseRenderOptions{
 		ID:          expectedID,
 		Commit:      expectedCommit,
@@ -129,6 +137,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		TriggeredBy: expectedTrigger,
 		Registry:    expectedRegistry,
 		GitTag:      expectedGitTag,
+		Date:        parsedTime,
 	}
 	vals, err := OverrideValuesWithBuildInfo(c1, c2, options)
 	if err != nil {
@@ -144,11 +153,12 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Build.TriggeredBy}}", expectedTrigger},
 		{"{{.Build.Registry}}", expectedRegistry},
 		{"{{.Build.GitTag}}", expectedGitTag},
+		{"{{.Build.Date}}", expectedTime},
 		{"{{.Values.born}}", eCurieBorn},
 		{"{{.Values.first}}", eCurieFirst},
 		{"{{.Values.last}}", eCurieLast},
 		{"{{.Values.from}}", eCurieFrom},
-		{"{{.Values.awards}}", eCurieAwards},
+		{"{{.Values.awards }}", eCurieAwards},
 	}
 	for _, test := range tests {
 		if o, err := executeTemplate(test.tpl, vals); err != nil || o != test.expect {


### PR DESCRIPTION
**Purpose of the PR:**

First classes `{{.Build.Date}}`, which defaults to `time.Now().UTC()` with `yyyyMMdd-HHmmssz` format.

**Fixes #161**

/cc @SteveLasker 