### PR TITLE
Enable --network and --label in build

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -43,6 +43,7 @@ type buildCmd struct {
 	isolation        string
 	oci              bool
 	dryRun           bool
+	network          string
 
 	opts *templating.BaseRenderOptions
 }
@@ -79,6 +80,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 	f.StringVarP(&r.registryPassword, "password", "p", "", "the password to use when logging into the registry")
 
 	f.StringVar(&r.isolation, "isolation", "default", "the isolation to use")
+	f.StringVar(&r.network, "network", "default", "set the networking mode during build")
 	f.StringVar(&r.target, "target", "", "specify a stage to build")
 	f.BoolVar(&r.pull, "pull", false, "attempt to pull a newer version of the base images")
 	f.BoolVar(&r.noCache, "no-cache", false, "true to ignore all cached layers when building the image")
@@ -112,9 +114,6 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 	rendered, err := templating.LoadAndRenderSteps(template, b.opts)
 	if err != nil {
 		return err
-	}
-	if rendered == "" {
-		return errors.New("rendered template was empty")
 	}
 
 	if debug {
@@ -209,6 +208,10 @@ func (b *buildCmd) createRunCmd() string {
 
 	if b.pull {
 		args = append(args, "--pull")
+	}
+
+	if b.network != "" {
+		args = append(args, fmt.Sprintf("--network=%s", b.network))
 	}
 
 	if b.noCache {

--- a/cli/build.go
+++ b/cli/build.go
@@ -35,6 +35,7 @@ type buildCmd struct {
 	tags             []string
 	buildArgs        []string
 	secretBuildArgs  []string
+	labels           []string
 	registryUserName string
 	registryPassword string
 	pull             bool
@@ -75,6 +76,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 	f.StringArrayVarP(&r.tags, "tag", "t", []string{}, "name and optionally a tag in the 'name:tag' format")
 	f.StringArrayVar(&r.buildArgs, "build-arg", []string{}, "set build time arguments")
 	f.StringArrayVar(&r.secretBuildArgs, "secret-build-arg", []string{}, "set secret build arguments")
+	f.StringArrayVar(&r.labels, "label", []string{}, "set metadata for an image")
 
 	f.StringVarP(&r.registryUserName, "username", "u", "", "the username to use when logging into the registry")
 	f.StringVarP(&r.registryPassword, "password", "p", "", "the password to use when logging into the registry")
@@ -212,6 +214,10 @@ func (b *buildCmd) createRunCmd() string {
 
 	if b.network != "" {
 		args = append(args, fmt.Sprintf("--network=%s", b.network))
+	}
+
+	for _, label := range b.labels {
+		args = append(args, "--label", label)
 	}
 
 	if b.noCache {

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -66,9 +65,6 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	rendered, err := templating.LoadAndRenderSteps(template, e.opts)
 	if err != nil {
 		return err
-	}
-	if rendered == "" {
-		return errors.New("rendered template was empty")
 	}
 
 	if debug {

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -97,6 +97,10 @@ func LoadAndRenderSteps(template *Template, opts *BaseRenderOptions) (string, er
 		return "", fmt.Errorf("Error while rendering templates: %v", err)
 	}
 
+	if rendered[template.Name] == "" {
+		return "", fmt.Errorf("Rendered template was empty. Original template: %s", template.Data)
+	}
+
 	return rendered[template.Name], nil
 }
 


### PR DESCRIPTION
**Purpose of the PR:**

- Enables `--network` during `build`, so that you can use a pre-defined network or `host` during `RUN` commands.
- Enables `--label` for metadata on images.
- Refactors some templating logic so that we just return an error if the template renders as an empty string rather than handling it in two places.