### PR TITLE
Windows support for volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,21 @@ For additional commands, try `make help`.
 ## Requirements
 
 - Docker
-- In order to run `build`, you must create an image called scanner. This image can be built using `docker build -f baseimages/scanner/Dockerfile -t scanner .` at the root of this repository.
+- There are also dependency images that are used throughout the pipeline. Refer to the `baseimages` folder for corresponding Dockerfiles to generate these images, and review the list below for Linux/Windows.
+
+## Linux Images
+
+The following images are required:
+
+- `scanner:linux`
+- `docker-cli:linux`
+- `ubuntu`
+
+## Windows Images
+
+- `scanner:windows`
+- `docker-cli:windows`
+- `microsoft/windowsservercore:1803`
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ docker build -f Windows.Dockerfile -t acb:windows .
 
 Using `make`:
 
-```bash
+```sh
 $ make
 ```
 
@@ -49,7 +49,7 @@ The following images are required:
 
 ## CLI
 
-```bash
+```sh
 $ acb --help
 
 Usage:
@@ -70,7 +70,7 @@ See `acb build --help` for a list of all parameters.
 
 Pushing to a registry:
 
-```bash
+```sh
 $ acb build -t "foo:bar" -f "Dockerfile" --push -r foo.azurecr.io -u foo -p foo "https://github.com/Azure/acr-builder.git"
 ```
 
@@ -78,6 +78,6 @@ $ acb build -t "foo:bar" -f "Dockerfile" --push -r foo.azurecr.io -u foo -p foo 
 
 See `acb exec --help` for a list of all parameters.
 
-```bash
+```sh
 $ acb exec --steps templating/testdata/helloworld/git-build.toml --values templating/testdata/helloworld/values.toml --id demo -r foo.azurecr.io -u username -p pw
 ```

--- a/README.md
+++ b/README.md
@@ -2,14 +2,28 @@
 
 [![Build Status](https://travis-ci.org/Azure/acr-builder.svg?branch=master)](https://travis-ci.org/Azure/acr-builder)
 
-## Building from source
+## Build
 
-Build using `make`:
+Using Docker:
+
+Execute the following commands from the root of the repository.
+
+Linux:
+
+```sh
+$ docker build -f Dockerfile -t acb:linux .
+```
+
+Windows:
+
+```sh
+$ docker build -f Windows.Dockerfile -t acb:windows .
+```
+
+Using `make`:
 
 ```bash
-$ make build
-
-go build -tags "" -ldflags "-w -X acb/version.GITCOMMIT=4fb5952-dirty -X acb/version.VERSION=v1.0.0" -o acb .
+$ make
 ```
 
 For additional commands, try `make help`.

--- a/baseimages/docker-cli/docker.Dockerfile
+++ b/baseimages/docker-cli/docker.Dockerfile
@@ -1,3 +1,3 @@
 # Required.
-# docker build -f baseimages/docker.Dockerfile -t docker .
+# docker build -f baseimages/docker.Dockerfile -t docker-cli:linux .
 FROM docker:18.03.1-ce-git

--- a/baseimages/docker-cli/docker.Windows.Dockerfile
+++ b/baseimages/docker-cli/docker.Windows.Dockerfile
@@ -1,3 +1,6 @@
+# Required.
+# docker build -f baseimages/docker.Windows.Dockerfile -t docker-cli:windows .
+
 ARG WINDOWS_IMAGE=microsoft/windowsservercore:1803
 FROM $WINDOWS_IMAGE as environment
 

--- a/baseimages/docker-cli/docker.Windows.Dockerfile
+++ b/baseimages/docker-cli/docker.Windows.Dockerfile
@@ -1,23 +1,9 @@
-# Required.
-# docker build -f baseimages/docker.Windows.Dockerfile -t docker .
 ARG WINDOWS_IMAGE=microsoft/windowsservercore:1803
+FROM $WINDOWS_IMAGE as environment
 
-FROM ${WINDOWS_IMAGE} as download
+# set the default shell as powershell.
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-ENV DOCKER_VERSION 18.03.0-ce
-
-# Utility to extract the Docker toolbox zip
-RUN Invoke-WebRequest 'http://constexpr.org/innoextract/files/innoextract-1.6-windows.zip' -OutFile 'innoextract.zip' -UseBasicParsing ; \
-    Expand-Archive innoextract.zip -DestinationPath C:\ ; \
-    Remove-Item -Path innoextract.zip
-
-RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
-    Invoke-WebRequest $('https://github.com/docker/toolbox/releases/download/v{0}/DockerToolbox-{0}.exe' -f $env:DOCKER_VERSION) -OutFile 'dockertoolbox.exe' -UseBasicParsing
-RUN /innoextract.exe dockertoolbox.exe
-
-FROM ${WINDOWS_IMAGE} as environment
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-COPY --from=download /app/docker.exe /
 
 # install MinGit (especially for "go get" and docker build by git repos) 
 ENV GIT_VERSION 2.17.1
@@ -27,15 +13,70 @@ ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \	
+	\
 	Write-Host 'Expanding ...'; \
 	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
 	Write-Host 'Removing ...'; \
 	Remove-Item git.zip -Force; \
+	\
 	Write-Host 'Updating PATH ...'; \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host 'git --version'; git --version; \
+	\
 	Write-Host 'Complete.';
 
-CMD [ "docker.exe" ]
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+
+# install go lang
+# ideally we should be able to use FROM golang:windowsservercore-1803. This is not done due to two reasons
+# 1. The go lang for 1803 tag is not available.
+# 2. The image pulls 2.11.1 version of MinGit which has an issue with git submodules command. https://github.com/git-for-windows/git/issues/1007#issuecomment-384281260 
+
+ENV GOLANG_VERSION 1.10.3
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = 'a3f19d4fc0f4b45836b349503e347e64e31ab830dedac2fc9c390836d4418edb'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+# Build the docker executable
+FROM environment as dockercli
+ARG DOCKER_CLI_LKG_COMMIT=c98c4080a323fb0e4fdf7429d8af4e2e946d09b5
+WORKDIR \\gopath\\src\\github.com\\docker\\cli
+RUN git clone https://github.com/docker/cli.git \gopath\src\github.com\docker\cli; \
+    git checkout $DOCKER_CLI_LKG_COMMIT; \
+    scripts\\make.ps1 -Binary -ForceBuildAll
+
+# setup the runtime environment
+FROM environment as runtime
+COPY --from=dockercli /gopath/src/github.com/docker/cli/build/docker.exe c:/docker/docker.exe
+RUN setx /M PATH $('c:\docker;{0}' -f $env:PATH);
+ENTRYPOINT [ "docker.exe" ]
+CMD [ "--help" ]

--- a/baseimages/scanner/README.md
+++ b/baseimages/scanner/README.md
@@ -4,14 +4,24 @@
 
 Using Docker:
 
-```bash
-docker build -f baseimages/scanner/Dockerfile -t scanner .
+Execute the following commands from the root of the repository.
+
+Linux:
+
+```sh
+$ docker build -f baseimages/scanner/Dockerfile -t scanner:linux .
+```
+
+Windows:
+
+```sh
+$ docker build -f baseimages/scanner/Windows.Dockerfile -t scanner:windows .
 ```
 
 Using make:
 
-```bash
-make
+```sh
+$ make
 ```
 
 ### Examples

--- a/baseimages/scanner/Windows.Dockerfile
+++ b/baseimages/scanner/Windows.Dockerfile
@@ -25,7 +25,7 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'git --version'; git --version; \
 	\
 	Write-Host 'Complete.';
 
@@ -70,7 +70,7 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 FROM environment as scanner
 WORKDIR \\gopath\\src\\github.com\\Azure\\acr-builder\\baseimages\\scanner
 COPY ./ /gopath/src/github.com/Azure/acr-builder
-RUN Write-Host ('Running build' ); \
+RUN Write-Host ('Running build'); \
     go build
 
 # setup the runtime environment

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -276,7 +276,7 @@ func (b *Builder) queryDigest(ctx context.Context, reference *models.ImageRefere
 			// Mount home
 			"--volume", builderutil.GetDockerSock(),
 			"--volume", homeVol + ":" + homeWorkDir,
-			"--env", "HOME=" + homeWorkDir,
+			"--env", homeEnv,
 
 			"docker",
 			"inspect",

--- a/builder/constants_linux.go
+++ b/builder/constants_linux.go
@@ -10,7 +10,9 @@ const (
 	// containerWorkspaceDir is the default working directory for a container.
 	containerWorkspaceDir = "/workspace"
 
-	scannerImageName = "scanner:linux"
+	scannerImageName   = "scanner:linux"
+	dockerCLIImageName = "docker-cli:linux"
+	configImageName    = "ubuntu"
 )
 
 var homeEnv = "HOME=" + homeWorkDir

--- a/builder/constants_linux.go
+++ b/builder/constants_linux.go
@@ -9,4 +9,8 @@ const (
 
 	// containerWorkspaceDir is the default working directory for a container.
 	containerWorkspaceDir = "/workspace"
+
+	scannerImageName = "scanner:linux"
 )
+
+var homeEnv = "HOME=" + homeWorkDir

--- a/builder/constants_windows.go
+++ b/builder/constants_windows.go
@@ -10,7 +10,9 @@ const (
 	// containerWorkspaceDir is the default working directory for a container.
 	containerWorkspaceDir = "c:\\workspace"
 
-	scannerImageName = "scanner:windows"
+	scannerImageName   = "scanner:windows"
+	dockerCLIImageName = "docker-cli:windows"
+	configImageName    = "microsoft/windowsservercore:1803"
 )
 
 var homeEnv = "USERPROFILE=" + homeWorkDir

--- a/builder/constants_windows.go
+++ b/builder/constants_windows.go
@@ -9,4 +9,8 @@ const (
 
 	// containerWorkspaceDir is the default working directory for a container.
 	containerWorkspaceDir = "c:\\workspace"
+
+	scannerImageName = "scanner:windows"
 )
+
+var homeEnv = "USERPROFILE=" + homeWorkDir

--- a/builder/context.go
+++ b/builder/context.go
@@ -18,10 +18,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const (
-	defaultScannerImage = "scanner"
-)
-
 var (
 	dependenciesRE = regexp.MustCompile(`^(\[{"image.*?\])$`)
 )
@@ -41,7 +37,7 @@ func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir st
 		// Mount home
 		"--volume", util.GetDockerSock(),
 		"--volume", homeVol+":"+homeWorkDir,
-		"--env", "HOME="+homeWorkDir,
+		"--env", homeEnv,
 
 		"--workdir", normalizeWorkDir(stepWorkDir),
 	)
@@ -60,9 +56,9 @@ func (b *Builder) scrapeDependencies(ctx context.Context, volName string, stepWo
 
 		// Mount home
 		"--volume", homeVol + ":" + homeWorkDir,
-		"--env", "HOME=" + homeWorkDir,
+		"--env", homeEnv,
 
-		defaultScannerImage,
+		scannerImageName,
 		"scan",
 		"-f", dockerfile,
 		"--destination", outputDir,

--- a/builder/login.go
+++ b/builder/login.go
@@ -33,7 +33,7 @@ func (b *Builder) dockerLogin(ctx context.Context, registry string, user string,
 		// Mount home
 		"--volume", util.GetDockerSock(),
 		"--volume", homeVol + ":" + homeWorkDir,
-		"--env", "HOME=" + homeWorkDir,
+		"--env", homeEnv,
 
 		"docker",
 		"login",

--- a/builder/login.go
+++ b/builder/login.go
@@ -35,7 +35,7 @@ func (b *Builder) dockerLogin(ctx context.Context, registry string, user string,
 		"--volume", homeVol + ":" + homeWorkDir,
 		"--env", homeEnv,
 
-		"docker",
+		dockerCLIImageName,
 		"login",
 		"--username", user,
 		"--password-stdin",

--- a/builder/push.go
+++ b/builder/push.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/Azure/acr-builder/util"
+	"github.com/google/uuid"
 )
 
 const (
@@ -20,7 +23,19 @@ func (b *Builder) pushWithRetries(ctx context.Context, images []string) error {
 	}
 
 	for _, img := range images {
-		args := []string{"docker", "push", img}
+		args := []string{
+			"docker",
+			"run",
+			"--name", fmt.Sprintf("acb_docker_push_%s", uuid.New()),
+			"--rm",
+
+			// Mount home
+			"--volume", util.GetDockerSock(),
+			"--volume", homeVol + ":" + homeWorkDir,
+			"--env", homeEnv,
+
+			"docker",
+			"push", img}
 
 		retry := 0
 		for retry < maxPushRetries {

--- a/builder/push.go
+++ b/builder/push.go
@@ -34,7 +34,7 @@ func (b *Builder) pushWithRetries(ctx context.Context, images []string) error {
 			"--volume", homeVol + ":" + homeWorkDir,
 			"--env", homeEnv,
 
-			"docker",
+			dockerCLIImageName,
 			"push", img}
 
 		retry := 0

--- a/builder/setup_linux.go
+++ b/builder/setup_linux.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/acr-builder/util"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
@@ -30,8 +29,7 @@ func (b *Builder) setupConfig(ctx context.Context) error {
 
 		// Home
 		"--volume", homeVol + ":" + homeWorkDir,
-		"--env", "HOME=" + homeWorkDir,
-		"--volume", util.GetDockerSock(),
+		"--env", homeEnv,
 		"--entrypoint", "bash",
 		"ubuntu",
 		"-c", "mkdir -p ~/.docker && cat << EOF > ~/.docker/config.json\n" + config + "\nEOF",

--- a/builder/setup_linux.go
+++ b/builder/setup_linux.go
@@ -31,7 +31,7 @@ func (b *Builder) setupConfig(ctx context.Context) error {
 		"--volume", homeVol + ":" + homeWorkDir,
 		"--env", homeEnv,
 		"--entrypoint", "bash",
-		"ubuntu",
+		configImageName,
 		"-c", "mkdir -p ~/.docker && cat << EOF > ~/.docker/config.json\n" + config + "\nEOF",
 	}
 

--- a/builder/setup_windows.go
+++ b/builder/setup_windows.go
@@ -28,7 +28,7 @@ func (b *Builder) setupConfig(ctx context.Context) error {
 		"--volume", homeVol + ":" + homeWorkDir,
 		"--env", homeEnv,
 		"--entrypoint", "powershell",
-		"microsoft/windowsservercore:1803",
+		configImageName,
 		"mkdir ~/.docker; echo \"" + config + "\" > ~/.docker/config.json",
 	}
 

--- a/builder/setup_windows.go
+++ b/builder/setup_windows.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/acr-builder/util"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
@@ -27,8 +26,7 @@ func (b *Builder) setupConfig(ctx context.Context) error {
 
 		// Home
 		"--volume", homeVol + ":" + homeWorkDir,
-		"--env", "HOME=" + homeWorkDir,
-		"--volume", util.GetDockerSock(),
+		"--env", homeEnv,
 		"--entrypoint", "powershell",
 		"microsoft/windowsservercore:1803",
 		"mkdir ~/.docker; echo \"" + config + "\" > ~/.docker/config.json",

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -34,7 +34,7 @@ The following variables can be accessed using `{{ .Build.VariableName }}`, where
 
 You can execute a pipeline with `exec`. It requires a `--steps` file and optionally a `--values` file. You can also use `--set` to override values specified in `--values`, or to provide new values not covered by `--values`.
 
-```bash
+```sh
 $ acb exec --steps templating/testdata/helloworld/git-build.toml --values templating/testdata/helloworld/values.toml --id demo
 
 ...
@@ -46,7 +46,7 @@ Successfully tagged acr-builder:demo
 
 Templating in `build` works the same as `exec`, except that you don't have to provide a `--steps` file.
 
-```bash
+```sh
 $ acb build https://github.com/Azure/acr-builder.git -f Dockerfile -t "acr-builder:{{.Build.ID}}" --id demo
 
 ...


### PR DESCRIPTION
**Purpose of the PR:**
- Adds the remaining support for Windows volumes.
- Enables `~/.docker/config.json` sharing for Windows across containers.
- Forces `push` to run in a container.
- Updates the docker CLI image for Windows.
- Updates docs.

**Fixes #134**