### PR TITLE
Add rm and detach

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -196,12 +196,11 @@ func (b *Builder) processVertex(ctx context.Context, pipeline *graph.Pipeline, p
 				}
 			}
 
-			args = b.getDockerRunArgs(volName, step.ID, stepWorkingDir)
+			args = b.getDockerRunArgs(volName, step.ID, stepWorkingDir, step.Rm)
 			args = append(args, "docker")
 			args = append(args, strings.Fields(step.Run)...)
-
 		} else {
-			args = b.getDockerRunArgs(b.workspaceDir, step.ID, step.WorkDir)
+			args = b.getDockerRunArgs(b.workspaceDir, step.ID, step.WorkDir, step.Rm)
 			for _, env := range step.Envs {
 				args = append(args, "--env", env)
 			}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -196,11 +196,11 @@ func (b *Builder) processVertex(ctx context.Context, pipeline *graph.Pipeline, p
 				}
 			}
 
-			args = b.getDockerRunArgs(volName, step.ID, stepWorkingDir, step.Rm, step.Detach)
+			args = b.getDockerRunArgs(volName, step.ID, stepWorkingDir, step.Ports, step.Rm, step.Detach)
 			args = append(args, "docker")
 			args = append(args, strings.Fields(step.Run)...)
 		} else {
-			args = b.getDockerRunArgs(b.workspaceDir, step.ID, step.WorkDir, step.Rm, step.Detach)
+			args = b.getDockerRunArgs(b.workspaceDir, step.ID, step.WorkDir, step.Ports, step.Rm, step.Detach)
 			for _, env := range step.Envs {
 				args = append(args, "--env", env)
 			}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -196,11 +196,11 @@ func (b *Builder) processVertex(ctx context.Context, pipeline *graph.Pipeline, p
 				}
 			}
 
-			args = b.getDockerRunArgs(volName, step.ID, stepWorkingDir, step.Rm)
+			args = b.getDockerRunArgs(volName, step.ID, stepWorkingDir, step.Rm, step.Detach)
 			args = append(args, "docker")
 			args = append(args, strings.Fields(step.Run)...)
 		} else {
-			args = b.getDockerRunArgs(b.workspaceDir, step.ID, step.WorkDir, step.Rm)
+			args = b.getDockerRunArgs(b.workspaceDir, step.ID, step.WorkDir, step.Rm, step.Detach)
 			for _, env := range step.Envs {
 				args = append(args, "--env", env)
 			}

--- a/builder/constants.go
+++ b/builder/constants.go
@@ -12,8 +12,6 @@ const (
 	// DockerHubRegistry is the docker hub registry
 	DockerHubRegistry = "registry.hub.docker.com"
 
-	rmContainer = true
-
 	// homeVol is the volume to manage $HOME
 	homeVol = "home"
 )

--- a/builder/context.go
+++ b/builder/context.go
@@ -23,7 +23,7 @@ var (
 )
 
 // getDockerRunArgs populates the args for running a Docker container.
-func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir string) []string {
+func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir string, rmContainer bool) []string {
 	args := []string{"docker", "run"}
 
 	if rmContainer {

--- a/builder/context.go
+++ b/builder/context.go
@@ -23,7 +23,13 @@ var (
 )
 
 // getDockerRunArgs populates the args for running a Docker container.
-func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir string, rmContainer bool, detach bool) []string {
+func (b *Builder) getDockerRunArgs(
+	volName string,
+	stepID string,
+	stepWorkDir string,
+	ports []string,
+	rmContainer bool,
+	detach bool) []string {
 	args := []string{"docker", "run"}
 
 	if rmContainer {
@@ -32,6 +38,10 @@ func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir st
 
 	if detach {
 		args = append(args, "--detach")
+	}
+
+	for _, port := range ports {
+		args = append(args, "-p", port)
 	}
 
 	args = append(args,

--- a/builder/context.go
+++ b/builder/context.go
@@ -23,11 +23,15 @@ var (
 )
 
 // getDockerRunArgs populates the args for running a Docker container.
-func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir string, rmContainer bool) []string {
+func (b *Builder) getDockerRunArgs(volName string, stepID string, stepWorkDir string, rmContainer bool, detach bool) []string {
 	args := []string{"docker", "run"}
 
 	if rmContainer {
 		args = append(args, "--rm")
+	}
+
+	if detach {
+		args = append(args, "--detach")
 	}
 
 	args = append(args,

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -70,6 +70,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		When:       []string{ImmediateExecutionToken},
 		StepStatus: Skipped,
 		Timeout:    defaultStepTimeoutInSeconds,
+		Detach:     true,
 	}
 
 	qazStep := &Step{

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -35,6 +35,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		ExitedWith: []int{0, 1, 2, 3, 4},
 		StepStatus: Skipped,
 		Timeout:    defaultStepTimeoutInSeconds,
+		Rm:         true,
 	}
 
 	bStep := &Step{

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -34,6 +34,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		When:       []string{ImmediateExecutionToken},
 		ExitedWith: []int{0, 1, 2, 3, 4},
 		StepStatus: Skipped,
+		Ports:      []string{"8000:8000", "8080:8080"},
 		Timeout:    defaultStepTimeoutInSeconds,
 		Rm:         true,
 	}

--- a/graph/step.go
+++ b/graph/step.go
@@ -35,6 +35,7 @@ type Step struct {
 	ExitedWith    []int    `yaml:"exitedWith"`
 	ExitedWithout []int    `yaml:"exitedWithout"`
 	Rm            bool     `yaml:"rm"`
+	Detach        bool     `yaml:"detach"`
 
 	StartTime  time.Time
 	EndTime    time.Time
@@ -82,6 +83,7 @@ func (s *Step) Equals(t *Step) bool {
 
 	if s.ID != t.ID ||
 		s.Rm != t.Rm ||
+		s.Detach != t.Detach ||
 		s.Run != t.Run ||
 		s.WorkDir != t.WorkDir ||
 		s.EntryPoint != t.EntryPoint ||

--- a/graph/step.go
+++ b/graph/step.go
@@ -30,10 +30,11 @@ type Step struct {
 	EntryPoint    string   `yaml:"entryPoint"`
 	Envs          []string `yaml:"envs"`
 	SecretEnvs    []string `yaml:"secretEnvs"`
-	Timeout       int      `yaml:"timeout"`
+	Ports         []string `yaml:"ports"`
 	When          []string `yaml:"when"`
 	ExitedWith    []int    `yaml:"exitedWith"`
 	ExitedWithout []int    `yaml:"exitedWithout"`
+	Timeout       int      `yaml:"timeout"`
 	Rm            bool     `yaml:"rm"`
 	Detach        bool     `yaml:"detach"`
 
@@ -87,6 +88,7 @@ func (s *Step) Equals(t *Step) bool {
 		s.Run != t.Run ||
 		s.WorkDir != t.WorkDir ||
 		s.EntryPoint != t.EntryPoint ||
+		!util.StringSequenceEquals(s.Ports, t.Ports) ||
 		!util.StringSequenceEquals(s.Envs, t.Envs) ||
 		!util.StringSequenceEquals(s.SecretEnvs, t.SecretEnvs) ||
 		s.Timeout != t.Timeout ||

--- a/graph/step.go
+++ b/graph/step.go
@@ -34,6 +34,7 @@ type Step struct {
 	When          []string `yaml:"when"`
 	ExitedWith    []int    `yaml:"exitedWith"`
 	ExitedWithout []int    `yaml:"exitedWithout"`
+	Rm            bool     `yaml:"rm"`
 
 	StartTime  time.Time
 	EndTime    time.Time
@@ -80,6 +81,7 @@ func (s *Step) Equals(t *Step) bool {
 	}
 
 	if s.ID != t.ID ||
+		s.Rm != t.Rm ||
 		s.Run != t.Run ||
 		s.WorkDir != t.WorkDir ||
 		s.EntryPoint != t.EntryPoint ||

--- a/graph/testdata/rally.yaml
+++ b/graph/testdata/rally.yaml
@@ -22,6 +22,7 @@ steps:
     run: azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu
     when: ["-"]
     rm: false
+    detach: true
 
   - id: C
     run: blah

--- a/graph/testdata/rally.yaml
+++ b/graph/testdata/rally.yaml
@@ -21,11 +21,13 @@ steps:
   - id: build-qux
     run: azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu
     when: ["-"]
+    rm: false
 
   - id: C
     run: blah
     when: ["-"]
     exitedWith: [0, 1, 2, 3, 4]
+    rm: true
 
   - id: build-bar
     run: azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/bar --cache-from=ubuntu

--- a/graph/testdata/rally.yaml
+++ b/graph/testdata/rally.yaml
@@ -27,6 +27,9 @@ steps:
   - id: C
     run: blah
     when: ["-"]
+    ports:
+      - "8000:8000"
+      - "8080:8080"
     exitedWith: [0, 1, 2, 3, 4]
     rm: true
 

--- a/templating/testdata/caching/cache.yaml
+++ b/templating/testdata/caching/cache.yaml
@@ -1,10 +1,13 @@
 steps:
   - id: "{{.Values.pullStep}}"
     run: docker pull golang:1.10.1-stretch
+    rm: true
 
   - id: build-foo
     run: build -f Dockerfile https://github.com/Azure/acr-builder.git --cache-from=ubuntu
+    rm: true
   
   - id: build-bar
     run: build -f Dockerfile https://github.com/Azure/acr-builder.git --cache-from=ubuntu
+    rm: true
     when: ["{{.Values.pullStep}}"]

--- a/templating/testdata/helloworld/context-build.yaml
+++ b/templating/testdata/helloworld/context-build.yaml
@@ -2,11 +2,14 @@
 # Run a git clone, which clones the context into `cloned-repository-ctx`
 steps:
   - run: git clone https://github.com/Azure/acr-builder.git cloned-repository-ctx
+    rm: true
 
   # Run `ls` on the cloned content
   - run: bash ls -la
     workDir: cloned-repository-ctx
+    rm: true
 
   # Build using the previously stored content from `cloned-repository-ctx`
   - run: build -f Dockerfile .
     workDir: cloned-repository-ctx
+    rm: true

--- a/templating/testdata/helloworld/git-build.yaml
+++ b/templating/testdata/helloworld/git-build.yaml
@@ -4,3 +4,4 @@ push: ["acr-builder:{{.Build.ID}}"]
 steps:
   - id: git-context
     run: "build -f Dockerfile -t acr-builder:{{.Build.ID}} https://github.com/Azure/acr-builder.git"
+    rm: true

--- a/templating/testdata/helloworld/manifest.yaml
+++ b/templating/testdata/helloworld/manifest.yaml
@@ -1,15 +1,22 @@
 steps:
   - id: git-context
     run: build -f Dockerfile -t acr-builder:{{.Build.ID}} -t acr-builder:foo https://github.com/Azure/acr-builder.git
+    rm: true
 
   - run: docker push {{.Build.Registry}}/acr-builder:latest
+    rm: true
 
   - run: docker push {{.Build.Registry}}/acr-builder:{{.Build.ID}}
+    rm: true
 
   - run: docker push {{.Build.Registry}}/acr-builder:foo
+    rm: true
 
   - run: docker manifest create --amend {{.Build.Registry}}/acr-builder:latest {{.Build.Registry}}/acr-builder:{{.Build.ID}} {{.Build.Registry}}/acr-builder:foo
+    rm: true
 
   - run: docker manifest annotate {{.Build.Registry}}/acr-builder:latest {{.Build.Registry}}/acr-builder:{{.Build.ID}} --os linux --arch amd64
+    rm: true
 
   - run: docker manifest push {{.Build.Registry}}/acr-builder
+    rm: true

--- a/templating/testdata/helloworld/tar-build.yaml
+++ b/templating/testdata/helloworld/tar-build.yaml
@@ -2,3 +2,4 @@
 
 steps:
   - run: build https://acrbuild.blob.core.windows.net/public/aspnetcore-helloworld.tar.gz -f HelloWorld/Dockerfile -t aspnetcore:{{.Build.ID}}
+    rm: true


### PR DESCRIPTION
**Purpose of the PR:**

- Adds `rm` and `detach` flags for steps. Both default to false.

NB: I've added `rm: true` to most of the examples so that when executing locally they're cleaned up nicely, but I think it makes sense to keep the default as false since cleanup won't matter on ACR and the default behavior of keeping them around is more useful for realistic complex pipelines.

**Fixes #172**