### PR TITLE
Add tests for image dependency parsing

### DIFF
--- a/baseimages/scanner/models/image_dependencies.go
+++ b/baseimages/scanner/models/image_dependencies.go
@@ -3,6 +3,10 @@
 
 package models
 
+import (
+	"fmt"
+)
+
 // ImageDependencies denotes docker image dependencies
 type ImageDependencies struct {
 	Image     *ImageReference   `json:"image"`
@@ -18,6 +22,30 @@ type ImageReference struct {
 	Tag        string `json:"tag,omitempty"`
 	Digest     string `json:"digest"`
 	Reference  string `json:"reference"`
+}
+
+// ImageReferencesEquals determines if two image references are equal.
+func ImageReferencesEquals(img1 *ImageReference, img2 *ImageReference) bool {
+	if img1 == nil && img2 == nil {
+		return true
+	}
+	if img1 == nil || img2 == nil {
+		return false
+	}
+
+	return img1.Registry == img2.Registry &&
+		img1.Repository == img2.Repository &&
+		img1.Tag == img2.Tag &&
+		img1.Digest == img2.Digest &&
+		img1.Reference == img2.Reference
+}
+
+// String returns a string representation of an ImageReference.
+func (i *ImageReference) String() string {
+	if i == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("Registry: %s\nRepository: %s\nTag: %s\nDigest: %s\nReference: %s\n", i.Registry, i.Repository, i.Tag, i.Digest, i.Reference)
 }
 
 // GitReference defines the reference to git source code

--- a/builder/context.go
+++ b/builder/context.go
@@ -94,26 +94,27 @@ func (b *Builder) scrapeDependencies(ctx context.Context, volName string, stepWo
 	var buf bytes.Buffer
 	err := b.taskManager.Run(ctx, args, nil, &buf, &buf, "")
 	output := strings.TrimSpace(buf.String())
-	fmt.Printf("Output from dependency scanning: %v\n", output)
 	if err != nil {
+		fmt.Printf("Output from dependency scanning: %s\n", output)
 		return nil, err
 	}
 
-	var deps []*models.ImageDependencies
+	return getImageDependencies(output)
+}
 
-	lines := strings.Split(output, "\n")
+func getImageDependencies(s string) ([]*models.ImageDependencies, error) {
+	var deps []*models.ImageDependencies
+	lines := strings.Split(s, "\n")
 	for _, line := range lines {
 		matches := dependenciesRE.FindStringSubmatch(line)
-
 		if len(matches) == 2 {
-			err = json.Unmarshal([]byte(matches[1]), &deps)
+			err := json.Unmarshal([]byte(matches[1]), &deps)
 			if err != nil {
 				return nil, err
 			}
 			break
 		}
 	}
-
 	return deps, nil
 }
 

--- a/builder/context_test.go
+++ b/builder/context_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/Azure/acr-builder/baseimages/scanner/models"
+)
+
+func TestGetImageDependencies(t *testing.T) {
+	json := `[{"image":{"registry":"registry.hub.docker.com","repository":"library/scanner","tag":"latest","digest":"","reference":"scanner:latest"},` +
+		`"runtime-dependency":{"registry":"registry.hub.docker.com","repository":"library/alpine","tag":"latest","digest":"","reference":"alpine:latest"},` +
+		`"buildtime-dependency":[{"registry":"registry.hub.docker.com","repository":"library/golang","tag":"1.10-alpine","digest":"test","reference":"golang:1.10-alpine"}],` +
+		`"git":{"git-head-revision":"abcdef"}}]`
+
+	deps, err := getImageDependencies(json)
+	if err != nil {
+		t.Fatalf("Unexpected err while parsing image deps: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("Expected 1 dependency, got %d", len(deps))
+	}
+	r := deps[0]
+	if r.Image == nil {
+		t.Fatal("Image shouldn't be nil")
+	}
+	if r.Runtime == nil {
+		t.Fatal("Runtime shouldn't be nil")
+	}
+	if len(r.Buildtime) != 1 {
+		t.Fatalf("Expected 1 buildtime dep, got %d", len(r.Buildtime))
+	}
+	if r.Git == nil {
+		t.Fatal("git shouldn't be nil")
+	}
+
+	expectedImage := &models.ImageReference{
+		Registry:   "registry.hub.docker.com",
+		Repository: "library/scanner",
+		Tag:        "latest",
+		Digest:     "",
+		Reference:  "scanner:latest",
+	}
+	expectedRuntimeDep := &models.ImageReference{
+		Registry:   "registry.hub.docker.com",
+		Repository: "library/alpine",
+		Tag:        "latest",
+		Digest:     "",
+		Reference:  "alpine:latest",
+	}
+	expectedBuildDep := &models.ImageReference{
+		Registry:   "registry.hub.docker.com",
+		Repository: "library/golang",
+		Tag:        "1.10-alpine",
+		Digest:     "test",
+		Reference:  "golang:1.10-alpine",
+	}
+	expectedGitHeadRev := "abcdef"
+
+	if !models.ImageReferencesEquals(r.Image, expectedImage) {
+		t.Errorf("Invalid image ref. Expected %s, got %s", expectedImage.String(), r.Image.String())
+	}
+	if !models.ImageReferencesEquals(r.Runtime, expectedRuntimeDep) {
+		t.Errorf("Invalid runtime dep. Expected %s, got %s", expectedRuntimeDep.String(), r.Runtime.String())
+	}
+	if !models.ImageReferencesEquals(r.Buildtime[0], expectedBuildDep) {
+		t.Errorf("Invalid buildtime dep. Expected %s, got %s", expectedBuildDep.String(), r.Buildtime[0].String())
+	}
+	if r.Git.GitHeadRev != expectedGitHeadRev {
+		t.Errorf("Invalid git head rev. Expected %s, got %s", expectedGitHeadRev, r.Git.GitHeadRev)
+	}
+}


### PR DESCRIPTION
**Purpose of the PR:**
- Only output results of dependency scanning if there was an error (so that we can aggregate them at the end of Build)
- Refactor dependency parsing slightly, add some helper methods and a unit test.