### PR TITLE
Aggregate image dependencies across multiple build steps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@ Windows.Dockerfile
 LICENSE
 *.md
 .vscode
+.github
+.travis.yml
+appveyor.yml

--- a/README.md
+++ b/README.md
@@ -54,22 +54,24 @@ Available Commands:
   init        Initialize a default template
   render      Render a template
   version     Print version information
+
+Flags:
+  -d, --debug   enable verbose output for debugging
+  -h, --help    help for acb
 ```
 
 ## Building an image
 
 See `acb build --help` for a list of all parameters.
 
-Pushing to a registry:
-
 ```sh
-$ docker run -v /var/run/docker.sock:/var/run/docker.sock acb build -t "foo:bar" -f "Dockerfile" --push -r foo.azurecr.io -u username -p password "https://github.com/Azure/acr-builder.git"
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock acb build https://github.com/Azure/acr-builder.git
 ```
 
-## Running a pipeline with a template
+## Running a pipeline
 
 See `acb exec --help` for a list of all parameters.
 
 ```sh
-$ docker run -v $(pwd):/workspace --workdir /workspace -v /var/run/docker.sock:/var/run/docker.sock acb exec --homevol $(pwd) --steps templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo -r foo.azurecr.io -u username -p password
+$ docker run -v $(pwd):/workspace --workdir /workspace -v /var/run/docker.sock:/var/run/docker.sock acb exec --homevol $(pwd) --steps templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo -r foo.azurecr.io
 ```

--- a/baseimages/scanner/cmd/download.go
+++ b/baseimages/scanner/cmd/download.go
@@ -5,7 +5,7 @@ package cmd
 
 import (
 	"context"
-	"fmt"
+	"log"
 
 	"io"
 	"time"
@@ -69,6 +69,6 @@ func (d *downloadCmd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Download complete, working directory: %s\n", workingDir)
+	log.Printf("Download complete, working directory: %s\n", workingDir)
 	return nil
 }

--- a/baseimages/scanner/scan/context.go
+++ b/baseimages/scanner/scan/context.go
@@ -100,10 +100,7 @@ func (s *Scanner) getContextFromURL(remoteURL string) (sourceType DockerSourceTy
 	progressOutput := streamformatter.NewProgressOutput(&buf)
 	r := progress.NewProgressReader(response.Body, progressOutput, response.ContentLength, "", "Downloading build context")
 	defer func(response *http.Response) {
-		err := response.Body.Close()
-		if err != nil {
-			fmt.Printf("Failed to close http response from url: %s, err: %v\n", remoteURL, err)
-		}
+		_ = response.Body.Close()
 	}(response)
 
 	err = s.getContextFromReader(r)

--- a/baseimages/scanner/scan/dependencies.go
+++ b/baseimages/scanner/scan/dependencies.go
@@ -6,6 +6,7 @@ package scan
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"strings"
@@ -182,7 +183,7 @@ func ResolveDockerfileDependencies(path string, buildArgs []string) (string, []s
 					originLookup[alias] = origin
 					// Just ignore the rest of the tokens...
 					if len(tokens) > 4 {
-						fmt.Printf("Ignoring chunks from FROM clause: %v", tokens[4:])
+						log.Printf("Ignoring chunks from FROM clause: %v", tokens[4:])
 					}
 				}
 			case "ARG":

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -85,13 +85,14 @@ func (b *Builder) RunAllBuildSteps(ctx context.Context, pipeline *graph.Pipeline
 	var deps []*models.ImageDependencies
 	for _, n := range pipeline.Dag.Nodes {
 		step := n.Value
+		log.Printf("Step ID %v marked as %v (elapsed time in seconds: %f)\n", step.ID, step.StepStatus, step.EndTime.Sub(step.StartTime).Seconds())
+
 		if !step.IsBuildStep() { // If the step isn't a build step, it won't have dependencies from the scanner.
 			continue
 		}
 		if err := b.populateDigests(ctx, step.ImageDependencies); err != nil {
 			return err
 		}
-		log.Printf("Step ID %v marked as %v (elapsed time in seconds: %f)\n", step.ID, step.StepStatus, step.EndTime.Sub(step.StartTime).Seconds())
 		if len(step.ImageDependencies) > 0 {
 			deps = append(deps, step.ImageDependencies...)
 		}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -279,15 +279,6 @@ func (b *Builder) queryDigest(ctx context.Context, reference *models.ImageRefere
 }
 
 func getRepoDigest(jsonContent string, reference *models.ImageReference) string {
-	// Input: ["docker@sha256:b90307d28c6a6ab3d1d873d03a26c53c282bb94d5b5fb62cc7c027c384fe50ce"], , docker
-	// Output: sha256:b90307d28c6a6ab3d1d873d03a26c53c282bb94d5b5fb62cc7c027c384fe50ce
-
-	// Input: ["test.azurecr.io/docker@sha256:b90307d28c6a6ab3d1d873d03a26c53c282bb94d5b5fb62cc7c027c384fe50ce"], test.azurecr.io, docker
-	// Output: sha256:b90307d28c6a6ab3d1d873d03a26c53c282bb94d5b5fb62cc7c027c384fe50ce
-
-	// Input: Invalid
-	// Output: <empty>
-
 	prefix := reference.Repository + "@"
 	// If the reference has "library/" prefixed, we have to remove it - otherwise
 	// we'll fail to query the digest, since image names aren't prefixed with "library/"
@@ -296,18 +287,14 @@ func getRepoDigest(jsonContent string, reference *models.ImageReference) string 
 	} else if len(reference.Registry) > 0 && reference.Registry != DockerHubRegistry {
 		prefix = reference.Registry + "/" + prefix
 	}
-
 	var digestList []string
 	if err := json.Unmarshal([]byte(jsonContent), &digestList); err != nil {
-		logrus.Warnf("Error deserializing %s to json, error: %s", jsonContent, err)
+		logrus.Warnf("Error deserializing %s to json, error: %v", jsonContent, err)
 	}
-
 	for _, digest := range digestList {
 		if strings.HasPrefix(digest, prefix) {
 			return digest[len(prefix):]
 		}
 	}
-
-	logrus.Warnf("Unable to find digest for %s in %s", prefix, jsonContent)
 	return ""
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/Azure/acr-builder/baseimages/scanner/models"
+)
+
+var (
+	acb = `["testing.azurecr-test.io/testing@sha256:69d6b9a450c69bde2005885fb4f850ded96596b9dd1949f4313b376e7518841d",` +
+		`"acrimageshub.azurecr.io/public/acr/acb@sha256:69d6b9a450c69bde2005885fb4f850ded96596b9dd1949f4313b376e7518841d",` +
+		`"mcr.microsoft.com/acr/acb@sha256:69d6b9a450c69bde2005885fb4f850ded96596b9dd1949f4313b376e7518841d"]`
+)
+
+func TestGetRepoDigest(t *testing.T) {
+	tests := []struct {
+		id       int
+		json     string
+		imgRef   *models.ImageReference
+		expected string
+	}{
+		{
+			1,
+			acb,
+			&models.ImageReference{
+				Registry:   "testing.azurecr-test.io",
+				Repository: "testing",
+			},
+			"sha256:69d6b9a450c69bde2005885fb4f850ded96596b9dd1949f4313b376e7518841d",
+		},
+		{
+			2,
+			acb,
+			&models.ImageReference{
+				Registry:   "acrimageshub.azurecr.io",
+				Repository: "public/acr/acb",
+			},
+			"sha256:69d6b9a450c69bde2005885fb4f850ded96596b9dd1949f4313b376e7518841d",
+		},
+		{
+			3,
+			acb,
+			&models.ImageReference{
+				Registry:   "mcr.microsoft.com",
+				Repository: "acr/acb",
+			},
+			"sha256:69d6b9a450c69bde2005885fb4f850ded96596b9dd1949f4313b376e7518841d",
+		},
+		{
+			4,
+			acb,
+			&models.ImageReference{
+				Registry:   "invalid",
+				Repository: "invalid",
+			},
+			"",
+		},
+	}
+	for _, test := range tests {
+		if actual := getRepoDigest(test.json, test.imgRef); actual != test.expected {
+			t.Errorf("invalid repo digest, test id: %d; expected %s but got %s", test.id, test.expected, actual)
+		}
+	}
+}

--- a/builder/context.go
+++ b/builder/context.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"path"
 	"regexp"
 	"strings"
@@ -88,14 +89,14 @@ func (b *Builder) scrapeDependencies(ctx context.Context, volName string, stepWo
 	}
 
 	if b.debug {
-		fmt.Printf("Scraping args: %v\n", args)
+		log.Printf("Scraping args: %v\n", args)
 	}
 
 	var buf bytes.Buffer
 	err := b.taskManager.Run(ctx, args, nil, &buf, &buf, "")
 	output := strings.TrimSpace(buf.String())
 	if err != nil {
-		fmt.Printf("Output from dependency scanning: %s\n", output)
+		log.Printf("Output from dependency scanning: %s\n", output)
 		return nil, err
 	}
 

--- a/builder/push.go
+++ b/builder/push.go
@@ -36,7 +36,9 @@ func (b *Builder) pushWithRetries(ctx context.Context, images []string) error {
 			"--env", homeEnv,
 
 			dockerCLIImageName,
-			"push", img}
+			"push",
+			img,
+		}
 
 		retry := 0
 		for retry < maxPushRetries {

--- a/builder/push.go
+++ b/builder/push.go
@@ -6,6 +6,7 @@ package builder
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -39,8 +40,7 @@ func (b *Builder) pushWithRetries(ctx context.Context, images []string) error {
 
 		retry := 0
 		for retry < maxPushRetries {
-			fmt.Printf("Pushing image: %s, attempt %d\n", img, retry+1)
-
+			log.Printf("Pushing image: %s, attempt %d\n", img, retry+1)
 			if err := b.taskManager.Run(ctx, args, nil, os.Stdout, os.Stderr, ""); err != nil {
 				time.Sleep(500 * time.Millisecond)
 				retry++

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -160,9 +160,7 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Err creating docker vol. Msg: %s, Err: %v", msg, err)
 			}
 			defer func() {
-				if msg, err := v.Delete(ctx); err != nil {
-					fmt.Printf("Failed to clean up docker vol: %s. Msg: %s, Err: %v\n", homeVolName, msg, err)
-				}
+				_, _ = v.Delete(ctx)
 			}()
 		}
 	} else {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -170,7 +170,6 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Using %s as the home volume\n", homeVolName)
-
 	builder := builder.NewBuilder(taskManager, debug, homeVolName)
 	defer builder.CleanAllBuildSteps(context.Background(), pipeline)
 	return builder.RunAllBuildSteps(ctx, pipeline)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -109,7 +109,6 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Using %s as the home volume\n", homeVolName)
 	builder := builder.NewBuilder(taskManager, debug, homeVolName)
 	defer builder.CleanAllBuildSteps(context.Background(), pipeline)
-
 	return builder.RunAllBuildSteps(ctx, pipeline)
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -97,9 +97,7 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Err creating docker vol. Msg: %s, Err: %v", msg, err)
 			}
 			defer func() {
-				if msg, err := v.Delete(ctx); err != nil {
-					fmt.Printf("Failed to clean up docker vol: %s. Msg: %s, Err: %v\n", homeVolName, msg, err)
-				}
+				_, _ = v.Delete(ctx)
 			}()
 		}
 	} else {

--- a/graph/step.go
+++ b/graph/step.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/acr-builder/baseimages/scanner/models"
@@ -57,17 +58,14 @@ func (s *Step) Validate() error {
 	if s.ID == "" {
 		return errMissingID
 	}
-
 	if s.Run == "" {
 		return errMissingRun
 	}
-
 	for _, dep := range s.When {
 		if dep == s.ID {
 			return NewSelfReferencedStepError(fmt.Sprintf("Step ID: %v is self-referenced", s.ID))
 		}
 	}
-
 	return nil
 }
 
@@ -116,4 +114,9 @@ func (s *Step) ShouldExecuteImmediately() bool {
 // HasNoWhen returns true if the Step has no when clause, false otherwise.
 func (s *Step) HasNoWhen() bool {
 	return len(s.When) == 0
+}
+
+// IsBuildStep returns true if the Step is a build step, false otherwise.
+func (s *Step) IsBuildStep() bool {
+	return strings.HasPrefix(s.Run, "build ")
 }

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package graph
+
+import "testing"
+
+func TestIsBuildStep(t *testing.T) {
+	tests := []struct {
+		step     *Step
+		expected bool
+	}{
+		{
+			&Step{
+				Run: "build -t foo .",
+			},
+			true,
+		},
+		{
+			&Step{
+				Run: "builder build -t foo .",
+			},
+			false,
+		},
+		{
+			&Step{
+				Run: "build",
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		if actual := test.step.IsBuildStep(); actual != test.expected {
+			t.Errorf("Expected step build step to be %v, but got %v", test.expected, actual)
+		}
+	}
+}

--- a/pkg/taskmanager/taskmanager.go
+++ b/pkg/taskmanager/taskmanager.go
@@ -5,8 +5,8 @@ package taskmanager
 
 import (
 	"context"
-	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"sync"
@@ -40,7 +40,7 @@ func (tm *TaskManager) Run(
 	cmdDir string) error {
 
 	if tm.DryRun {
-		fmt.Printf("[DRY RUN] Args: %v\n", args)
+		log.Printf("[DRY RUN] Args: %v\n", args)
 		return nil
 	}
 
@@ -77,7 +77,7 @@ func (tm *TaskManager) Run(
 	case <-ctx.Done():
 		go func() {
 			if err := cmd.Process.Kill(); err != nil {
-				fmt.Printf("Failed to kill process. Path: %s, Args: %v, Err: %v", cmd.Path, cmd.Args, err)
+				log.Printf("Failed to kill process. Path: %s, Args: %v, Err: %v", cmd.Path, cmd.Args, err)
 			}
 		}()
 


### PR DESCRIPTION
**Purpose of the PR:**

- Aggregate all image dependencies across multiple `build` steps and flush this information once at the end of the entire pipeline. 
- Simplify DAG traversal by first-classing the root node; `Nodes` will consist of all other vertexes, making a `range` loop easier.
- Update dockerignore to add a few additional files
- When querying digest, use `buf` instead of `os.StdErr`, this is a bug.
- Remove unused mutex from `builder`
- Misc. small refactorings
- Add a test for `getRepoDigest`
- Update README
- Use `log` instead of `fmt` in several places to add timing information in critical sections.
- Ignore errors in several places which are unrecoverable

**Fixes #184**