### PR TITLE
Disable automatic registry prefix for docker run

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -128,8 +128,11 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// After the template has rendered, we have to parse the tags again
-	// so we can properly set the push targets.
+	// so we can properly set the build/push tags.
 	b.tags = util.ParseTags(rendered)
+	for i := range b.tags {
+		b.tags[i] = util.PrefixRegistryToImageName(b.opts.Registry, b.tags[i])
+	}
 
 	procManager := procmanager.NewProcManager(b.dryRun)
 	defaultStep := &graph.Step{
@@ -141,9 +144,7 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 
 	push := []string{}
 	if b.push {
-		for _, img := range b.tags {
-			push = append(push, img)
-		}
+		push = b.tags
 	}
 
 	// TODO: create secrets

--- a/graph/task.go
+++ b/graph/task.go
@@ -144,9 +144,6 @@ func (t *Task) initialize() error {
 			s.CompletedChan = make(chan bool)
 		}
 
-		// Adjust the command so that the ACR registry is prefixed for all tags
-		s.Cmd = util.PrefixTags(s.Cmd, t.RegistryName)
-
 		// Mark the step as skipped initially
 		s.StepStatus = Skipped
 

--- a/util/prefixes.go
+++ b/util/prefixes.go
@@ -17,20 +17,3 @@ func PrefixRegistryToImageName(registry string, img string) string {
 
 	return img
 }
-
-// PrefixTags prefixes tags in the specified command and returns the new command.
-func PrefixTags(cmd string, registry string) string {
-	if registry == "" {
-		return cmd
-	}
-
-	fields := strings.Fields(cmd)
-
-	for i := 1; i < len(fields); i++ {
-		if fields[i-1] == "-t" || fields[i-1] == "--tag" {
-			fields[i] = PrefixRegistryToImageName(registry, fields[i])
-		}
-	}
-
-	return strings.Join(fields, " ")
-}

--- a/util/prefixes_test.go
+++ b/util/prefixes_test.go
@@ -14,30 +14,11 @@ func TestPrefixRegistryToImageName(t *testing.T) {
 		{"", "foo:latest", "foo:latest"},
 		{"foo", "someimg", "foo/someimg"},
 		{"foo", "someimg:bar", "foo/someimg:bar"},
+		{"foo", "library/someimg:bar", "library/someimg:bar"},
 	}
 
 	for _, test := range tests {
 		actual := PrefixRegistryToImageName(test.registry, test.img)
-		if actual != test.expected {
-			t.Errorf("expected %s, got %s", test.expected, actual)
-		}
-	}
-}
-
-func TestPrefixTags(t *testing.T) {
-	tests := []struct {
-		registry string
-		cmd      string
-		expected string
-	}{
-		{"foo.azurecr.io", "build -f Dockerfile . -t test:latest --tag bar", "build -f Dockerfile . -t foo.azurecr.io/test:latest --tag foo.azurecr.io/bar"},
-		{"", "build -t bar/foo:latest . --tag bar", "build -t bar/foo:latest . --tag bar"},
-		{"foo.azurecr.io", "build -f Dockerfile . -t foo.azurecr.io/test:latest", "build -f Dockerfile . -t foo.azurecr.io/test:latest"},
-		{"foo.azurecr.io", "build -f Dockerfile -t library/test:latest", "build -f Dockerfile -t library/test:latest"},
-	}
-
-	for _, test := range tests {
-		actual := PrefixTags(test.cmd, test.registry)
 		if actual != test.expected {
 			t.Errorf("expected %s, got %s", test.expected, actual)
 		}


### PR DESCRIPTION
**Purpose of the PR:**

Disable automatic registry prefix for docker run.

**Fixes #199** 