### PR TITLE
Rename CLI steps to task

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 **Purpose of the PR:**
 
-**Fixes #**  *[Refer closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)*
+**Fixes #**

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ $ docker run -v /var/run/docker.sock:/var/run/docker.sock acb build https://gith
 See `acb exec --help` for a list of all parameters.
 
 ```sh
-$ docker run -v $(pwd):/workspace --workdir /workspace -v /var/run/docker.sock:/var/run/docker.sock acb exec --homevol $(pwd) --steps templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo -r foo.azurecr.io
+$ docker run -v $(pwd):/workspace --workdir /workspace -v /var/run/docker.sock:/var/run/docker.sock acb exec --homevol $(pwd) --task templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo -r foo.azurecr.io
 ```
 
 ## Rendering a template locally
 
 ```sh
-$ acb render --steps acb.yaml --values values.yaml
+$ acb render --task acb.yaml --values values.yaml
 ```
 
 If your template uses `.Run.ID` or other `.Run` variables, refer to the full list of parameters using `acb render --help`.

--- a/builder/context.go
+++ b/builder/context.go
@@ -31,7 +31,7 @@ func (b *Builder) getDockerRunArgs(
 	step *graph.Step) []string {
 	args := []string{"docker", "run"}
 
-	if step.Rm {
+	if !step.Keep {
 		args = append(args, "--rm")
 	}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -59,7 +59,7 @@ func newExecCmd(out io.Writer) *cobra.Command {
 }
 
 func (e *execCmd) run(cmd *cobra.Command, args []string) error {
-	template, err := templating.LoadTemplate(e.opts.StepsFile)
+	template, err := templating.LoadTemplate(e.opts.TaskFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -39,7 +39,7 @@ func newRenderCmd(out io.Writer) *cobra.Command {
 }
 
 func (r *renderCmd) run(cmd *cobra.Command, args []string) error {
-	template, err := templating.LoadTemplate(r.opts.StepsFile)
+	template, err := templating.LoadTemplate(r.opts.TaskFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -14,7 +14,7 @@ import (
 
 // AddBaseRenderingOptions adds base rendering options to the specified flagset and maps the flags
 // to the options struct.
-func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions, cmd *cobra.Command, usesSteps bool) {
+func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions, cmd *cobra.Command, usesTask bool) {
 
 	// Templates & values files
 	f.StringVar(&opts.ValuesFile, "values", "", "the values file to use")
@@ -31,9 +31,9 @@ func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions
 
 	opts.Date = time.Now().UTC()
 
-	// exec and render both use steps and it's required, but build doesn't
-	if usesSteps {
-		f.StringVar(&opts.StepsFile, "steps", "", "the steps file to use")
-		_ = cmd.MarkFlagRequired("steps")
+	// exec and render both use task and it's required, but build doesn't
+	if usesTask {
+		f.StringVar(&opts.TaskFile, "task", "", "the task file to use")
+		_ = cmd.MarkFlagRequired("task")
 	}
 }

--- a/docs/acb.md
+++ b/docs/acb.md
@@ -18,7 +18,7 @@ when: [string, string, ...] (optional)
 exitedWith: [int, int, ...] (optional)
 exitedWithout: [int, int, ...] (optional)
 timeout: int (in seconds) (optional)
-rm: bool (optional)
+keep: bool (optional)
 detach: bool (optional)
 startDelay: int (in seconds) (optional)
 ```
@@ -36,7 +36,7 @@ For details on each specific property in a Step, follow these links:
 - [exitedWith](#exitedwith)
 - [exitedWithout](#exitedwithout)
 - [timeout](#timeout)
-- [rm](#rm)
+- [keep](#keep)
 - [detach](#deatch)
 - [startDelay](#startdelay)
 
@@ -104,9 +104,9 @@ The `cmd` property of a step specifies which image to use when running the opera
 
 `timeout` is the maximum duration for a step to execute.
 
-### rm
+### keep
 
-`rm` determines whether or not the step's container should be removed after execution.
+`keep` determines whether or not the step's container should be kept after execution.
 
 ### detach
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -32,10 +32,10 @@ The following variables can be accessed using `{{ .Run.VariableName }}`, where `
 
 ## Tasks
 
-You can execute a task with `exec`. It requires a `--steps` file and optionally a `--values` file. You can also use `--set` to override values specified in `--values`, or to provide new values not covered by `--values`.
+You can execute a task with `exec`. It requires a `--task` file and optionally a `--values` file. You can also use `--set` to override values specified in `--values`, or to provide new values not covered by `--values`.
 
 ```sh
-$ acb exec --steps templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo
+$ acb exec --task templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo
 
 ...
 
@@ -44,7 +44,7 @@ Successfully tagged acr-builder:demo
 
 ## Build
 
-Templating in `build` works the same as `exec`, except that you don't have to provide a `--steps` file.
+Templating in `build` works the same as `exec`, except that you don't have to provide a `--task` file.
 
 ```sh
 $ acb build https://github.com/Azure/acr-builder.git -f Dockerfile -t "acr-builder:{{.Run.ID}}" --id demo

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -33,7 +33,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		StepStatus: Skipped,
 		Ports:      []string{"8000:8000", "8080:8080"},
 		Timeout:    defaultStepTimeoutInSeconds,
-		Rm:         true,
+		Keep:       true,
 	}
 
 	bStep := &Step{

--- a/graph/step.go
+++ b/graph/step.go
@@ -36,7 +36,7 @@ type Step struct {
 	ExitedWith    []int    `yaml:"exitedWith"`
 	ExitedWithout []int    `yaml:"exitedWithout"`
 	Timeout       int      `yaml:"timeout"`
-	Rm            bool     `yaml:"rm"`
+	Keep          bool     `yaml:"keep"`
 	Detach        bool     `yaml:"detach"`
 	StartDelay    int      `yaml:"startDelay"`
 	Privileged    bool     `yaml:"privileged"`
@@ -82,7 +82,7 @@ func (s *Step) Equals(t *Step) bool {
 	}
 
 	if s.ID != t.ID ||
-		s.Rm != t.Rm ||
+		s.Keep != t.Keep ||
 		s.Detach != t.Detach ||
 		s.Cmd != t.Cmd ||
 		s.WorkDir != t.WorkDir ||

--- a/graph/testdata/rally.yaml
+++ b/graph/testdata/rally.yaml
@@ -21,7 +21,6 @@ steps:
   - id: build-qux
     cmd: azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu
     when: ["-"]
-    rm: false
     detach: true
     startDelay: 50
 
@@ -32,7 +31,7 @@ steps:
       - "8000:8000"
       - "8080:8080"
     exitedWith: [0, 1, 2, 3, 4]
-    rm: true
+    keep: true
 
   - id: build-bar
     cmd: azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/bar --cache-from=ubuntu

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -13,8 +13,8 @@ import (
 
 // BaseRenderOptions represents additional information for the composition of the final rendering.
 type BaseRenderOptions struct {
-	// Path to the steps file. Required.
-	StepsFile string
+	// Path to the task file. Required.
+	TaskFile string
 
 	// Path to a values file. Optional.
 	ValuesFile string

--- a/templating/testdata/caching/cache.yaml
+++ b/templating/testdata/caching/cache.yaml
@@ -1,13 +1,10 @@
 steps:
   - id: "{{.Values.pullStep}}"
     cmd: docker pull golang:1.10.1-stretch
-    rm: true
 
   - id: build-foo
     cmd: build -f Dockerfile https://github.com/Azure/acr-builder.git --cache-from=ubuntu
-    rm: true
   
   - id: build-bar
     cmd: build -f Dockerfile https://github.com/Azure/acr-builder.git --cache-from=ubuntu
-    rm: true
     when: ["{{.Values.pullStep}}"]

--- a/templating/testdata/helloworld/context-build.yaml
+++ b/templating/testdata/helloworld/context-build.yaml
@@ -2,14 +2,11 @@
 # Run a git clone, which clones the context into `cloned-repository-ctx`
 steps:
   - cmd: git clone https://github.com/Azure/acr-builder.git cloned-repository-ctx
-    rm: true
 
   # Run `ls` on the cloned content
   - cmd: bash ls -la
     workDir: cloned-repository-ctx
-    rm: true
 
   # Build using the previously stored content from `cloned-repository-ctx`
   - cmd: build -f Dockerfile .
     workDir: cloned-repository-ctx
-    rm: true

--- a/templating/testdata/helloworld/git-build.yaml
+++ b/templating/testdata/helloworld/git-build.yaml
@@ -6,4 +6,3 @@ push: ["acr-builder:{{.Run.ID}}"]
 steps:
   - id: git-context
     cmd: "build -f Dockerfile -t acr-builder:{{.Run.ID}} https://github.com/Azure/acr-builder.git"
-    rm: true

--- a/templating/testdata/helloworld/manifest.yaml
+++ b/templating/testdata/helloworld/manifest.yaml
@@ -1,22 +1,15 @@
 steps:
   - id: git-context
     cmd: build -f Dockerfile -t acr-builder:{{.Run.ID}} -t acr-builder:foo https://github.com/Azure/acr-builder.git
-    rm: true
 
   - cmd: docker push {{.Run.Registry}}/acr-builder:latest
-    rm: true
 
   - cmd: docker push {{.Run.Registry}}/acr-builder:{{.Run.ID}}
-    rm: true
 
   - cmd: docker push {{.Run.Registry}}/acr-builder:foo
-    rm: true
 
   - cmd: docker manifest create --amend {{.Run.Registry}}/acr-builder:latest {{.Run.Registry}}/acr-builder:{{.Run.ID}} {{.Run.Registry}}/acr-builder:foo
-    rm: true
 
   - cmd: docker manifest annotate {{.Run.Registry}}/acr-builder:latest {{.Run.Registry}}/acr-builder:{{.Run.ID}} --os linux --arch amd64
-    rm: true
 
   - cmd: docker manifest push {{.Run.Registry}}/acr-builder
-    rm: true

--- a/templating/testdata/helloworld/tar-build.yaml
+++ b/templating/testdata/helloworld/tar-build.yaml
@@ -2,4 +2,3 @@
 
 steps:
   - cmd: build https://acrbuild.blob.core.windows.net/public/aspnetcore-helloworld.tar.gz -f HelloWorld/Dockerfile -t aspnetcore:{{.Run.ID}}
-    rm: true


### PR DESCRIPTION
**Purpose of the PR:**

- Rename `--steps` to `--task`

- Remove `Rm` from Step in favor of `Keep`, so that the default behavior is to remove the container upon execution.

**Fixes #206**

**Fixes #202**