### PR TITLE
Best-effort csv-style parsing for cmd, add back in args

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -196,7 +196,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 		if step.EntryPoint != "" {
 			args = append(args, "--entrypoint", step.EntryPoint)
 		}
-		args = append(args, strings.Fields(step.Cmd)...)
+		args = append(args, step.GetArgs()...)
 	}
 
 	if b.debug {

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -64,7 +64,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 
 	quxStep := &Step{
 		ID:         "build-qux",
-		Cmd:        "azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu",
+		Args:       []string{"azure/images/acr-builder", "build", "-f", "Dockerfile", "https://github.com/ehotinger/qux", "--cache-from=ubuntu"},
 		When:       []string{ImmediateExecutionToken},
 		StepStatus: Skipped,
 		Timeout:    defaultStepTimeoutInSeconds,
@@ -156,7 +156,7 @@ func verifyChildren(expected map[string]*Step, actual []*Node) error {
 	for _, node := range actual {
 		if lookup, ok := expected[node.Name]; ok {
 			if !lookup.Equals(node.Value) {
-				return fmt.Errorf("Node provided does not match the expected node for %v", node.Name)
+				return fmt.Errorf("Node provided: %v does not match the expected: %v", lookup, node.Value)
 			}
 		} else {
 			return fmt.Errorf("Node %v was not expected", node.Name)

--- a/graph/step.go
+++ b/graph/step.go
@@ -4,8 +4,10 @@
 package graph
 
 import (
+	"encoding/csv"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/acr-builder/baseimages/scanner/models"
@@ -19,13 +21,14 @@ const (
 
 var (
 	errMissingID    = errors.New("Step is missing an ID")
-	errMissingProps = errors.New("Step is missing a cmd or build property")
+	errMissingProps = errors.New("Step is missing a cmd, build, or args property")
 )
 
 // Step is a step in the execution task.
 type Step struct {
 	ID            string   `yaml:"id"`
 	Cmd           string   `yaml:"cmd"`
+	Args          []string `yaml:"args"`
 	Build         string   `yaml:"build"`
 	WorkDir       string   `yaml:"workDir"`
 	EntryPoint    string   `yaml:"entryPoint"`
@@ -60,7 +63,7 @@ func (s *Step) Validate() error {
 	if s.ID == "" {
 		return errMissingID
 	}
-	if s.Cmd == "" && s.Build == "" {
+	if s.Cmd == "" && s.Build == "" && len(s.Args) <= 0 {
 		return errMissingProps
 	}
 	for _, dep := range s.When {
@@ -76,16 +79,15 @@ func (s *Step) Equals(t *Step) bool {
 	if s == nil && t == nil {
 		return true
 	}
-
 	if s == nil || t == nil {
 		return false
 	}
-
 	if s.ID != t.ID ||
 		s.Keep != t.Keep ||
 		s.Detach != t.Detach ||
 		s.Cmd != t.Cmd ||
 		s.Build != t.Build ||
+		!util.StringSequenceEquals(s.Args, t.Args) ||
 		s.WorkDir != t.WorkDir ||
 		s.EntryPoint != t.EntryPoint ||
 		!util.StringSequenceEquals(s.Ports, t.Ports) ||
@@ -124,4 +126,22 @@ func (s *Step) HasNoWhen() bool {
 // IsBuildStep returns true if the Step is a build step, false otherwise.
 func (s *Step) IsBuildStep() bool {
 	return s.Build != ""
+}
+
+// GetArgs returns the Step's args.
+func (s *Step) GetArgs() []string {
+	if len(s.Args) <= 0 {
+		s.Args = toArgv(s.Cmd)
+	}
+	return s.Args
+}
+
+func toArgv(s string) []string {
+	r := csv.NewReader(strings.NewReader(s))
+	r.Comma = ' '
+	split, err := r.Read()
+	if err != nil {
+		return strings.Fields(s)
+	}
+	return split
 }

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 package graph
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/Azure/acr-builder/util"
+)
 
 func TestIsBuildStep(t *testing.T) {
 	tests := []struct {
@@ -32,6 +37,40 @@ func TestIsBuildStep(t *testing.T) {
 	for _, test := range tests {
 		if actual := test.step.IsBuildStep(); actual != test.expected {
 			t.Errorf("Expected step build step to be %v, but got %v", test.expected, actual)
+		}
+	}
+}
+
+func TestQuoteSplit(t *testing.T) {
+	tests := []struct {
+		cmd      string
+		expected []string
+	}{
+		{
+			cmd:      "a b c d",
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			cmd:      `docker run --rm -it bash -c "echo hello-world >> test.txt && ls && cat test.txt"`,
+			expected: []string{"docker", "run", "--rm", "-it", "bash", "-c", "echo hello-world >> test.txt && ls && cat test.txt"},
+		},
+		{
+			cmd:      "\"hello world\" > foo.txt",
+			expected: []string{"hello world", ">", "foo.txt"},
+		},
+		{
+			cmd:      "bash echo -e \"FROM busybox\nCOPY /hello /\nRUN cat /hello > Dockerfile\"",
+			expected: []string{"bash", "echo", "-e", "FROM busybox\nCOPY /hello /\nRUN cat /hello > Dockerfile"},
+		},
+		{
+			cmd:      "docker run --rm -it bash -c \"echo FROM hello-world > dockerfile && ls\"",
+			expected: []string{"docker", "run", "--rm", "-it", "bash", "-c", "echo FROM hello-world > dockerfile && ls"},
+		},
+	}
+
+	for _, test := range tests {
+		if actual := toArgv(test.cmd); !util.StringSequenceEquals(test.expected, actual) {
+			t.Errorf("Got %v but expected %v after splitting", strings.Join(actual, ","), strings.Join(test.expected, ","))
 		}
 	}
 }

--- a/graph/task.go
+++ b/graph/task.go
@@ -147,8 +147,10 @@ func (t *Task) initialize() error {
 		// Mark the step as skipped initially
 		s.StepStatus = Skipped
 
-		s.Tags = util.ParseTags(s.Build)
-		s.BuildArgs = util.ParseBuildArgs(s.Build)
+		if s.IsBuildStep() {
+			s.Tags = util.ParseTags(s.Build)
+			s.BuildArgs = util.ParseBuildArgs(s.Build)
+		}
 	}
 
 	t.Push = getNormalizedDockerImageNames(t.Push, t.RegistryName)

--- a/graph/testdata/rally.yaml
+++ b/graph/testdata/rally.yaml
@@ -19,7 +19,7 @@ steps:
     exitedWithout: [0, 255]
 
   - id: build-qux
-    cmd: azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu
+    args: ['azure/images/acr-builder', 'build', '-f', 'Dockerfile', 'https://github.com/ehotinger/qux', '--cache-from=ubuntu']
     when: ["-"]
     detach: true
     startDelay: 50


### PR DESCRIPTION
**Purpose of the PR:**

- Adds back in the `args` field. `cmd` takes precedence over `args` if both are present. Double quotes are the only thing we support, there is no reason to use single quotes as a delimiter.

Examples:

```
steps:
  - cmd: bash -c "echo FROM busybox\nCOPY /hello RUN cat /hello > third.txt"
  - cmd: bash -c "echo hello-world > test.txt && ls && cat test.txt"
  - args:
    - 'bash'
    - '-c'
    - |
        echo "FROM busybox
        COPY /hello 
        RUN cat /hello" > someDockerfile
```

**Fixes #198**