### PR TITLE
Invoke /bin/sh by default to use the shell's field splitting algorithm

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -185,23 +185,13 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 
 			step.Build = replacePositionalContext(step.Build, ".")
 		}
-
-		args = b.getDockerRunArgs(volName, workDir, step)
-		args = append(args, "docker", "build")
-		args = append(args, strings.Fields(step.Build)...)
+		args = b.getDockerRunArgs(volName, workDir, step, nil, "", "docker build "+step.Build)
 	} else {
-		args = b.getDockerRunArgs(b.workspaceDir, step.WorkDir, step)
-		for _, env := range step.Envs {
-			args = append(args, "--env", env)
-		}
-		if step.EntryPoint != "" {
-			args = append(args, "--entrypoint", step.EntryPoint)
-		}
-		args = append(args, step.GetArgs()...)
+		args = b.getDockerRunArgs(b.workspaceDir, step.WorkDir, step, step.Envs, step.EntryPoint, step.Cmd)
 	}
 
 	if b.debug {
-		log.Printf("Step args: %v\n", args)
+		log.Printf("Step args: %v\n", strings.Join(args, ", "))
 	}
 	// NB: ctx refers to the global ctx here,
 	// so when running individual processes use the individual

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -64,7 +64,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 
 	quxStep := &Step{
 		ID:         "build-qux",
-		Args:       []string{"azure/images/acr-builder", "build", "-f", "Dockerfile", "https://github.com/ehotinger/qux", "--cache-from=ubuntu"},
+		Cmd:        "azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu",
 		When:       []string{ImmediateExecutionToken},
 		StepStatus: Skipped,
 		Timeout:    defaultStepTimeoutInSeconds,

--- a/graph/step.go
+++ b/graph/step.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	errMissingID    = errors.New("Step is missing an ID")
-	errMissingProps = errors.New("Step is missing a cmd, or build property")
+	errMissingProps = errors.New("Step is missing a cmd or build property")
 )
 
 // Step is a step in the execution task.

--- a/graph/step.go
+++ b/graph/step.go
@@ -4,10 +4,8 @@
 package graph
 
 import (
-	"encoding/csv"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/acr-builder/baseimages/scanner/models"
@@ -21,14 +19,13 @@ const (
 
 var (
 	errMissingID    = errors.New("Step is missing an ID")
-	errMissingProps = errors.New("Step is missing a cmd, build, or args property")
+	errMissingProps = errors.New("Step is missing a cmd, or build property")
 )
 
 // Step is a step in the execution task.
 type Step struct {
 	ID            string   `yaml:"id"`
 	Cmd           string   `yaml:"cmd"`
-	Args          []string `yaml:"args"`
 	Build         string   `yaml:"build"`
 	WorkDir       string   `yaml:"workDir"`
 	EntryPoint    string   `yaml:"entryPoint"`
@@ -63,7 +60,7 @@ func (s *Step) Validate() error {
 	if s.ID == "" {
 		return errMissingID
 	}
-	if s.Cmd == "" && s.Build == "" && len(s.Args) <= 0 {
+	if s.Cmd == "" && s.Build == "" {
 		return errMissingProps
 	}
 	for _, dep := range s.When {
@@ -87,7 +84,6 @@ func (s *Step) Equals(t *Step) bool {
 		s.Detach != t.Detach ||
 		s.Cmd != t.Cmd ||
 		s.Build != t.Build ||
-		!util.StringSequenceEquals(s.Args, t.Args) ||
 		s.WorkDir != t.WorkDir ||
 		s.EntryPoint != t.EntryPoint ||
 		!util.StringSequenceEquals(s.Ports, t.Ports) ||
@@ -126,22 +122,4 @@ func (s *Step) HasNoWhen() bool {
 // IsBuildStep returns true if the Step is a build step, false otherwise.
 func (s *Step) IsBuildStep() bool {
 	return s.Build != ""
-}
-
-// GetArgs returns the Step's args.
-func (s *Step) GetArgs() []string {
-	if len(s.Args) <= 0 {
-		s.Args = toArgv(s.Cmd)
-	}
-	return s.Args
-}
-
-func toArgv(s string) []string {
-	r := csv.NewReader(strings.NewReader(s))
-	r.Comma = ' '
-	split, err := r.Read()
-	if err != nil {
-		return strings.Fields(s)
-	}
-	return split
 }

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -3,10 +3,7 @@
 package graph
 
 import (
-	"strings"
 	"testing"
-
-	"github.com/Azure/acr-builder/util"
 )
 
 func TestIsBuildStep(t *testing.T) {
@@ -37,40 +34,6 @@ func TestIsBuildStep(t *testing.T) {
 	for _, test := range tests {
 		if actual := test.step.IsBuildStep(); actual != test.expected {
 			t.Errorf("Expected step build step to be %v, but got %v", test.expected, actual)
-		}
-	}
-}
-
-func TestQuoteSplit(t *testing.T) {
-	tests := []struct {
-		cmd      string
-		expected []string
-	}{
-		{
-			cmd:      "a b c d",
-			expected: []string{"a", "b", "c", "d"},
-		},
-		{
-			cmd:      `docker run --rm -it bash -c "echo hello-world >> test.txt && ls && cat test.txt"`,
-			expected: []string{"docker", "run", "--rm", "-it", "bash", "-c", "echo hello-world >> test.txt && ls && cat test.txt"},
-		},
-		{
-			cmd:      "\"hello world\" > foo.txt",
-			expected: []string{"hello world", ">", "foo.txt"},
-		},
-		{
-			cmd:      "bash echo -e \"FROM busybox\nCOPY /hello /\nRUN cat /hello > Dockerfile\"",
-			expected: []string{"bash", "echo", "-e", "FROM busybox\nCOPY /hello /\nRUN cat /hello > Dockerfile"},
-		},
-		{
-			cmd:      "docker run --rm -it bash -c \"echo FROM hello-world > dockerfile && ls\"",
-			expected: []string{"docker", "run", "--rm", "-it", "bash", "-c", "echo FROM hello-world > dockerfile && ls"},
-		},
-	}
-
-	for _, test := range tests {
-		if actual := toArgv(test.cmd); !util.StringSequenceEquals(test.expected, actual) {
-			t.Errorf("Got %v but expected %v after splitting", strings.Join(actual, ","), strings.Join(test.expected, ","))
 		}
 	}
 }

--- a/graph/testdata/rally.yaml
+++ b/graph/testdata/rally.yaml
@@ -19,7 +19,7 @@ steps:
     exitedWithout: [0, 255]
 
   - id: build-qux
-    args: ['azure/images/acr-builder', 'build', '-f', 'Dockerfile', 'https://github.com/ehotinger/qux', '--cache-from=ubuntu']
+    cmd: 'azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu'
     when: ["-"]
     detach: true
     startDelay: 50


### PR DESCRIPTION
**Purpose of the PR:**

Invoke /bin/sh by default to use the shell's field splitting algorithm

**Example**

```
steps:
  - cmd: |
      bash -c 'echo "FROM golang:1.10-alpine AS gobuild-base
      RUN apk add --no-cache \
        git \
        make

      FROM gobuild-base AS base
      WORKDIR /go/src/github.com/ehotinger/scratch
      COPY . .
      RUN make static && mv scratch /usr/bin/scratch

      FROM scratch
      COPY --from=base /usr/bin/scratch /usr/bin/scratch
      ENTRYPOINT [ "scratch" ]
      CMD [ ]" > test.Dockerfile && cat test.Dockerfile'
  - cmd: 'bash ls'
  - build: -f test.Dockerfile -t scratch .
  - cmd: 'bash rm test.Dockerfile'
  - cmd: 'bash ls'
```