### PR TITLE
Backport the quote fix for dependency parsing for Windows

### DIFF
--- a/pkg/grok/docker_file.go
+++ b/pkg/grok/docker_file.go
@@ -109,5 +109,12 @@ func ParseAssignment(in string) (string, string, error) {
 	if len(values) != 2 {
 		return "", "", fmt.Errorf("%s cannot be split into 2 tokens with '='", in)
 	}
-	return values[0], values[1], nil
+	val := removeSurroundingQuotes(values[1])
+	return values[0], val, nil
+}
+
+// removeSurroundingQuotes trims double quotes, then single quotes.
+func removeSurroundingQuotes(s string) string {
+	s = strings.Trim(s, `"`)
+	return strings.Trim(s, `'`)
 }


### PR DESCRIPTION
**Purpose of the PR:**

Backport the quote fix for dependency parsing for Windows.

See https://github.com/Azure/acr/issues/115 for more info.