### PR TITLE
Allows specifying network during run

### DIFF
--- a/builder/context.go
+++ b/builder/context.go
@@ -61,6 +61,9 @@ func (b *Builder) getDockerRunArgs(
 	if step.User != "" {
 		sb.WriteString(" --user " + step.User)
 	}
+	if step.Network != "" {
+		sb.WriteString(" --network " + step.Network)
+	}
 	for _, env := range envs {
 		sb.WriteString(" --env " + env)
 	}

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDagCreation_ValidFile(t *testing.T) {
-	task, err := UnmarshalTaskFromFile("testdata/rally.yaml", "", "", "")
+	task, err := UnmarshalTaskFromFile("testdata/acb.yaml", "", "", "")
 	if err != nil {
 		t.Fatalf("Failed to create task from file. Err: %v", err)
 	}
@@ -84,6 +84,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		Timeout:    defaultStepTimeoutInSeconds,
 		Privileged: true,
 		User:       "root",
+		Network:    "host",
 	}
 
 	dict := make(map[string]*Step)

--- a/graph/step.go
+++ b/graph/step.go
@@ -41,6 +41,7 @@ type Step struct {
 	StartDelay    int      `yaml:"startDelay"`
 	Privileged    bool     `yaml:"privileged"`
 	User          string   `yaml:"user"`
+	Network       string   `yaml:"network"`
 
 	StartTime  time.Time
 	EndTime    time.Time
@@ -98,7 +99,8 @@ func (s *Step) Equals(t *Step) bool {
 		s.EndTime != t.EndTime ||
 		s.StepStatus != t.StepStatus ||
 		s.Privileged != t.Privileged ||
-		s.User != t.User {
+		s.User != t.User ||
+		s.Network != t.Network {
 		return false
 	}
 

--- a/graph/testdata/acb.yaml
+++ b/graph/testdata/acb.yaml
@@ -52,3 +52,4 @@ steps:
     build: "-f Dockerfile https://github.com/ehotinger/qaz --cache-from=ubuntu"
     privileged: true
     user: root
+    network: host


### PR DESCRIPTION
**Purpose of the PR:**

Allows specifying `--network` during run.

This is not fully first-classing networks, merely supporting a few basic scenarios to start off with. See https://github.com/Azure/acr-builder/issues/143 for more details.