### PR TITLE
Include newline when printing procmanager fails

### DIFF
--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -77,7 +77,7 @@ func (pm *ProcManager) Run(
 	case <-ctx.Done():
 		go func() {
 			if err := cmd.Process.Kill(); err != nil {
-				log.Printf("Failed to kill process. Path: %s, Args: %v, Err: %v", cmd.Path, cmd.Args, err)
+				log.Printf("Failed to kill process. Path: %s, Args: %v, Err: %v\n", cmd.Path, cmd.Args, err)
 			}
 		}()
 


### PR DESCRIPTION
**Purpose of the PR:**

Include a newline when printing failures to kill a process.