### PR TITLE
Rename --task to -f and --encoded-task to --encoded-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ $ docker run -v /var/run/docker.sock:/var/run/docker.sock acb build https://gith
 See `acb exec --help` for a list of all parameters.
 
 ```sh
-$ docker run -v $(pwd):/workspace --workdir /workspace -v /var/run/docker.sock:/var/run/docker.sock acb exec --homevol $(pwd) --task templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo -r foo.azurecr.io
+$ docker run -v $(pwd):/workspace --workdir /workspace -v /var/run/docker.sock:/var/run/docker.sock acb exec --homevol $(pwd) -f templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo -r foo.azurecr.io
 ```
 
 ## Rendering a template locally
 
 ```sh
-$ acb render --task acb.yaml --values values.yaml
+$ acb render -f acb.yaml --values values.yaml
 ```
 
 If your template uses `.Run.ID` or other `.Run` variables, refer to the full list of parameters using `acb render --help`.

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -36,7 +36,7 @@ func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions
 
 	// exec and render both use task and it's required, but build doesn't
 	if usesTask {
-		f.StringVar(&opts.TaskFile, "task", "", "the task file to use")
-		f.StringVar(&opts.Base64EncodedTaskFile, "encoded-task", "", "a Base64 encoded task file")
+		f.StringVarP(&opts.TaskFile, "file", "f", "", "the task file to use")
+		f.StringVar(&opts.Base64EncodedTaskFile, "encoded-file", "", "a Base64 encoded task file")
 	}
 }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -33,10 +33,10 @@ The following variables can be accessed using `{{ .Run.VariableName }}`, where `
 
 ## Tasks
 
-You can execute a task with `exec`. It requires a `--task` file and optionally a `--values` file. You can also use `--set` to override values specified in `--values`, or to provide new values not covered by `--values`.
+You can execute a task with `exec`. It requires a `-f` file and optionally a `--values` file. You can also use `--set` to override values specified in `--values`, or to provide new values not covered by `--values`.
 
 ```sh
-$ acb exec --task templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo
+$ acb exec -f templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo
 
 ...
 
@@ -45,7 +45,7 @@ Successfully tagged acr-builder:demo
 
 ## Build
 
-Templating in `build` works the same as `exec`, except that you don't have to provide a `--task` file.
+Templating in `build` works the same as `exec`, except that you don't have to provide a `Task` file.
 
 ```sh
 $ acb build https://github.com/Azure/acr-builder.git -f Dockerfile -t "acr-builder:{{.Run.ID}}" --id demo


### PR DESCRIPTION
**Purpose of the PR:**

Rename `--task` to `-f` and `--encoded-task` to `--encoded-file`

**Fixes #**

Closes #273 