### PR TITLE
Add support for expose

### DIFF
--- a/builder/context.go
+++ b/builder/context.go
@@ -59,6 +59,9 @@ func (b *Builder) getDockerRunArgs(
 	for _, port := range step.Ports {
 		sb.WriteString(" -p " + port)
 	}
+	for _, exp := range step.Expose {
+		sb.WriteString(" --expose " + exp)
+	}
 	if step.Privileged {
 		sb.WriteString(" --privileged")
 	}

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -39,6 +39,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		ExitedWith: []int{0, 1, 2, 3, 4},
 		StepStatus: Skipped,
 		Ports:      []string{"8000:8000", "8080:8080"},
+		Expose:     []string{"80", "81"},
 		Timeout:    defaultStepTimeoutInSeconds,
 		Keep:       true,
 		Isolation:  "default",

--- a/graph/step.go
+++ b/graph/step.go
@@ -6,9 +6,9 @@ package graph
 import (
 	"errors"
 	"fmt"
-	"time"
-	"strings"
 	"runtime"
+	"strings"
+	"time"
 
 	"github.com/Azure/acr-builder/pkg/image"
 	"github.com/Azure/acr-builder/util"
@@ -34,6 +34,7 @@ type Step struct {
 	EntryPoint       string   `yaml:"entryPoint"`
 	Envs             []string `yaml:"env"`
 	SecretEnvs       []string `yaml:"secretEnvs"`
+	Expose           []string `yaml:"expose"`
 	Ports            []string `yaml:"ports"`
 	When             []string `yaml:"when"`
 	ExitedWith       []int    `yaml:"exitedWith"`
@@ -94,6 +95,7 @@ func (s *Step) Equals(t *Step) bool {
 		s.WorkingDirectory != t.WorkingDirectory ||
 		s.EntryPoint != t.EntryPoint ||
 		!util.StringSequenceEquals(s.Ports, t.Ports) ||
+		!util.StringSequenceEquals(s.Expose, t.Expose) ||
 		!util.StringSequenceEquals(s.Envs, t.Envs) ||
 		!util.StringSequenceEquals(s.SecretEnvs, t.SecretEnvs) ||
 		s.Timeout != t.Timeout ||
@@ -144,6 +146,7 @@ func (s *Step) IsPushStep() bool {
 	return len(s.Push) > 0
 }
 
+// UpdateBuildStepWithDefaults updates a build step with hyperv isolation on Windows.
 func (s *Step) UpdateBuildStepWithDefaults() {
 	if s.IsBuildStep() && runtime.GOOS == "windows" && !strings.Contains(s.Build, "--isolation") {
 		s.Build = fmt.Sprintf("--isolation hyperv %s", s.Build)

--- a/graph/testdata/acb.yaml
+++ b/graph/testdata/acb.yaml
@@ -31,6 +31,9 @@ steps:
     ports:
       - "8000:8000"
       - "8080:8080"
+    expose:
+      - "80"
+      - "81"
     exitedWith: [0, 1, 2, 3, 4]
     keep: true
     isolation: default


### PR DESCRIPTION
**Purpose of the PR:**

- Add support for expose
- Remove check for `--dry-run`, always try to set up the default network and home volume during a dry run.

**Fixes #293**

A follow-up issue: https://github.com/Azure/acr-builder/issues/296