### PR TITLE
Print out the network being used during step execution

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -39,7 +39,7 @@ func NewBuilder(pm *procmanager.ProcManager, debug bool, workspaceDir string) *B
 // RunTask executes a Task.
 func (b *Builder) RunTask(ctx context.Context, task *graph.Task) error {
 	for _, network := range task.Networks {
-		log.Printf("Creating Docker network: %s\n", network.Name)
+		log.Printf("Creating Docker network: %s, driver: '%s'\n", network.Name, network.Driver)
 		if msg, err := network.Create(ctx, b.procManager); err != nil {
 			return fmt.Errorf("Failed to create network: %s, err: %v, msg: %s", network.Name, err, msg)
 		}
@@ -172,7 +172,7 @@ func (b *Builder) processVertex(ctx context.Context, task *graph.Task, parent *g
 }
 
 func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
-	log.Printf("Executing step ID: %s. Step working directory: '%s'\n", step.ID, step.WorkingDirectory)
+	log.Printf("Executing step ID: %s. Working directory: '%s', Network: '%s'\n", step.ID, step.WorkingDirectory, step.Network)
 	if step.StartDelay > 0 {
 		log.Printf("Waiting %d seconds before executing step ID: %s\n", step.StartDelay, step.ID)
 		time.Sleep(time.Duration(step.StartDelay) * time.Second)

--- a/graph/network_test.go
+++ b/graph/network_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/Azure/acr-builder/util"
+)
+
+func TestNetwork(t *testing.T) {
+	tests := []struct {
+		name               string
+		ipv6               bool
+		driver             string
+		expectedCreateArgs []string
+		expectedDeleteArgs []string
+	}{
+		{
+			"foo",
+			true,
+			"",
+			[]string{"docker", "network", "create", "foo", "--ipv6"},
+			[]string{"docker", "network", "rm", "foo"},
+		},
+		{
+			"bar",
+			false,
+			"nat",
+			[]string{"docker", "network", "create", "bar", "--driver", "nat"},
+			[]string{"docker", "network", "rm", "bar"},
+		},
+	}
+
+	for _, test := range tests {
+		network := NewNetwork(test.name, test.ipv6, test.driver)
+		if network.Name != test.name {
+			t.Fatalf("Expected network name: %s but got %s", test.name, network.Name)
+		}
+		if network.Ipv6 != test.ipv6 {
+			t.Fatalf("Expected network: %s to have ipv6 of %v, but got %v", test.name, test.ipv6, network.Ipv6)
+		}
+		if network.Driver != test.driver {
+			t.Fatalf("Expected network: %s to have driver of %s, but got %s", test.name, test.driver, network.Driver)
+		}
+
+		if actual := network.getDockerCreateArgs(); !util.StringSequenceEquals(actual, test.expectedCreateArgs) {
+			t.Fatalf("Expected %v as the create args, but got %v", test.expectedCreateArgs, actual)
+		}
+
+		if actual := network.getDockerRmArgs(); !util.StringSequenceEquals(actual, test.expectedDeleteArgs) {
+			t.Fatalf("Expected %v as the delete args, but got %v", test.expectedCreateArgs, actual)
+		}
+	}
+}

--- a/graph/step.go
+++ b/graph/step.go
@@ -122,7 +122,6 @@ func (s *Step) ShouldExecuteImmediately() bool {
 	if len(s.When) == 1 && s.When[0] == ImmediateExecutionToken {
 		return true
 	}
-
 	return false
 }
 

--- a/graph/task.go
+++ b/graph/task.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"fmt"
 	"io/ioutil"
+	"runtime"
 
 	"github.com/Azure/acr-builder/scan"
 	"github.com/Azure/acr-builder/util"
@@ -101,12 +102,15 @@ func NewTask(
 
 // initialize normalizes a Task's values.
 func (t *Task) initialize() error {
-
 	// Add the default network if none are specified.
 	// Only add the default network if we're using tasks.
 	addDefaultNetworkToSteps := false
 	if !t.IsBuildTask && len(t.Networks) <= 0 {
-		t.Networks = append(t.Networks, NewNetwork(DefaultNetworkName, false))
+		defaultNetwork := NewNetwork(DefaultNetworkName, false, "bridge")
+		if runtime.GOOS == "windows" {
+			defaultNetwork.Driver = "nat"
+		}
+		t.Networks = append(t.Networks, defaultNetwork)
 		addDefaultNetworkToSteps = true
 	}
 


### PR DESCRIPTION
**Purpose of the PR:**

- Explicitly declare the driver as `bridge` on Linux and `nat` on Windows.
- Add the `Driver` property to `Network`.
- Print out the network being used during step execution
- Print out the network's driver type during network creation.
- Add unit tests for network

**Fixes #296**