### PR TITLE
Add acb.yaml as the default task name

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -108,10 +108,10 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	procManager := procmanager.NewProcManager(b.dryRun)
-	if b.opts.SharedContextDirectory == "" {
+	if b.opts.SharedVolume == "" {
 		if !b.dryRun {
 			homeVolName := fmt.Sprintf("%s%s", volume.VolumePrefix, uuid.New())
-			b.opts.SharedContextDirectory = homeVolName
+			b.opts.SharedVolume = homeVolName
 			v := volume.NewVolume(homeVolName, procManager)
 			if msg, err := v.Create(ctx); err != nil {
 				return fmt.Errorf("Err creating docker vol. Msg: %s, Err: %v", msg, err)
@@ -121,7 +121,7 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 			}()
 		}
 	}
-	log.Printf("Using %s as the home volume\n", b.opts.SharedContextDirectory)
+	log.Printf("Using %s as the home volume\n", b.opts.SharedVolume)
 
 	// Render the template and create the task.
 	task, err := b.createBuildTask()
@@ -133,7 +133,7 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	builder := builder.NewBuilder(procManager, debug, b.opts.SharedContextDirectory)
+	builder := builder.NewBuilder(procManager, debug, b.opts.SharedVolume)
 	defer builder.CleanTask(context.Background(), task)
 	return builder.RunTask(ctx, task)
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -20,9 +19,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const execLongDesc = `
+const (
+	execUse = "exec"
+
+	execShortDesc = "Execute a task"
+
+	execLongDesc = `
 This command can be used to execute a task.
 `
+
+	defaultTaskFile = "acb.yaml"
+)
 
 type execCmd struct {
 	out    io.Writer
@@ -41,8 +48,8 @@ func newExecCmd(out io.Writer) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "exec",
-		Short: "Execute a task",
+		Use:   execUse,
+		Short: execShortDesc,
 		Long:  execLongDesc,
 		RunE:  e.run,
 	}
@@ -58,9 +65,7 @@ func newExecCmd(out io.Writer) *cobra.Command {
 }
 
 func (e *execCmd) run(cmd *cobra.Command, args []string) error {
-	if e.opts.TaskFile == "" && e.opts.Base64EncodedTaskFile == "" {
-		return errors.New("A task file or Base64 encoded task file is required")
-	}
+	e.setDefaultTaskFile()
 
 	ctx := context.Background()
 
@@ -122,4 +127,10 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 
 func (e *execCmd) validateCmdArgs() error {
 	return validateRegistryCreds(e.registryUser, e.registryPw)
+}
+
+func (e *execCmd) setDefaultTaskFile() {
+	if e.opts.TaskFile == "" && e.opts.Base64EncodedTaskFile == "" {
+		e.opts.TaskFile = defaultTaskFile
+	}
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -70,10 +70,10 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	procManager := procmanager.NewProcManager(e.dryRun)
-	if e.opts.SharedContextDirectory == "" {
+	if e.opts.SharedVolume == "" {
 		if !e.dryRun {
 			homeVolName := fmt.Sprintf("%s%s", volume.VolumePrefix, uuid.New())
-			e.opts.SharedContextDirectory = homeVolName
+			e.opts.SharedVolume = homeVolName
 			v := volume.NewVolume(homeVolName, procManager)
 			if msg, err := v.Create(ctx); err != nil {
 				return fmt.Errorf("Err creating docker vol. Msg: %s, Err: %v", msg, err)
@@ -83,7 +83,7 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 			}()
 		}
 	}
-	log.Printf("Using %s as the home volume\n", e.opts.SharedContextDirectory)
+	log.Printf("Using %s as the home volume\n", e.opts.SharedVolume)
 
 	var template *templating.Template
 	var err error
@@ -120,7 +120,7 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	builder := builder.NewBuilder(procManager, debug, e.opts.SharedContextDirectory)
+	builder := builder.NewBuilder(procManager, debug, e.opts.SharedVolume)
 	defer builder.CleanTask(context.Background(), task)
 	return builder.RunTask(ctx, task)
 }

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Azure/acr-builder/templating"
+)
+
+func TestNewExecCmd_Defaults(t *testing.T) {
+	tests := []struct {
+		taskFile         string
+		encodedFile      string
+		expectedTaskFile string
+	}{
+		{"", "foo", ""},
+		{"", "", defaultTaskFile},
+		{"foo.yaml", "", "foo.yaml"},
+	}
+
+	for _, test := range tests {
+		cmd := &execCmd{}
+		cmd.opts = &templating.BaseRenderOptions{
+			TaskFile:              test.taskFile,
+			Base64EncodedTaskFile: test.encodedFile,
+		}
+		cmd.setDefaultTaskFile()
+
+		if cmd.opts.TaskFile != test.expectedTaskFile {
+			t.Errorf("Expected %s as the task file but got %s", test.expectedTaskFile, cmd.opts.TaskFile)
+		}
+	}
+}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -22,7 +22,7 @@ func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions
 	f.StringVar(&opts.Base64EncodedValuesFile, "encoded-values", "", "a Base64 encoded values file (overrides the values file if one is specified)")
 	f.StringArrayVar(&opts.TemplateValues, "set", []string{}, "set values on the command line (use `--set` multiple times or use commas: key1=val1,key2=val2)")
 
-	f.StringVar(&opts.SharedContextDirectory, "homevol", "", "the home volume to use")
+	f.StringVar(&opts.SharedVolume, "homevol", "", "the home volume to use")
 
 	// Base rendering options
 	f.StringVar(&opts.ID, "id", "", "the build ID")

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -29,7 +29,7 @@ The following variables can be accessed using `{{ .Run.VariableName }}`, where `
 - Registry
 - GitTag
 - Date
-- SharedContextDirectory
+- SharedVolume
 
 ## Tasks
 

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -52,8 +52,8 @@ type BaseRenderOptions struct {
 	// Date is the UTC date of the run.
 	Date time.Time
 
-	// SharedContextDirectory is the name of the shared context directory.
-	SharedContextDirectory string
+	// SharedVolume is the name of the shared volume.
+	SharedVolume string
 
 	// OS is the GOOS.
 	OS string
@@ -69,16 +69,16 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 			"ID": opts.ID,
 		},
 		"Run": map[string]interface{}{
-			"ID":          opts.ID,
-			"Commit":      opts.Commit,
-			"Repository":  opts.Repository,
-			"Branch":      opts.Branch,
-			"GitTag":      opts.GitTag,
-			"TriggeredBy": opts.TriggeredBy,
-			"Registry":    opts.Registry,
-			"Date":        opts.Date.Format("20060102-150405z"), // yyyyMMdd-HHmmssz
-			"SharedContextDirectory": opts.SharedContextDirectory,
-			"OS": opts.OS,
+			"ID":           opts.ID,
+			"Commit":       opts.Commit,
+			"Repository":   opts.Repository,
+			"Branch":       opts.Branch,
+			"GitTag":       opts.GitTag,
+			"TriggeredBy":  opts.TriggeredBy,
+			"Registry":     opts.Registry,
+			"Date":         opts.Date.Format("20060102-150405z"), // yyyyMMdd-HHmmssz
+			"SharedVolume": opts.SharedVolume,
+			"OS":           opts.OS,
 			// "Arch": opts.Architecture, // TODO: Not exposed yet.
 		},
 	}

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -127,7 +127,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	expectedTrigger := "triggered from someone cool!!1"
 	expectedRegistry := "foo.azurecr.io"
 	expectedGitTag := "some git tag"
-	expectedSharedContextDirectory := "acb_home_vol_12345"
+	expectedSharedVolume := "acb_home_vol_12345"
 	expectedOS := "linux"
 	// expectedArch := "amd64" // TODO: Not exposed yet.
 
@@ -139,16 +139,16 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	expectedTime := "20100520-131422z"
 
 	options := &BaseRenderOptions{
-		ID:          expectedID,
-		Commit:      expectedCommit,
-		Repository:  expectedRepo,
-		Branch:      expectedBranch,
-		TriggeredBy: expectedTrigger,
-		Registry:    expectedRegistry,
-		GitTag:      expectedGitTag,
-		Date:        parsedTime,
-		SharedContextDirectory: expectedSharedContextDirectory,
-		OS: expectedOS,
+		ID:           expectedID,
+		Commit:       expectedCommit,
+		Repository:   expectedRepo,
+		Branch:       expectedBranch,
+		TriggeredBy:  expectedTrigger,
+		Registry:     expectedRegistry,
+		GitTag:       expectedGitTag,
+		Date:         parsedTime,
+		SharedVolume: expectedSharedVolume,
+		OS:           expectedOS,
 		// Architecture: expectedArch, // TODO: Not exposed yet.
 	}
 	vals, err := OverrideValuesWithBuildInfo(c1, c2, options)
@@ -167,7 +167,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Run.Registry}}", expectedRegistry},
 		{"{{.Run.GitTag}}", expectedGitTag},
 		{"{{.Run.Date}}", expectedTime},
-		{"{{.Run.SharedContextDirectory}}", expectedSharedContextDirectory},
+		{"{{.Run.SharedVolume}}", expectedSharedVolume},
 		{"{{.Run.OS}}", expectedOS},
 		// {"{{.Run.Architecture}}", expectedArch}, // TODO: Not exposed yet.
 		{"{{.Values.born}}", eCurieBorn},


### PR DESCRIPTION
**Purpose of the PR:**

- Add `acb.yaml` as the default task name if neither a task file nor an encoded file are provided.
- Rename `SharedContextDirectory` to `SharedVolume`

**Fixes #268**
**Fixes #291**