### PR TITLE
Expose .Run.Architecture

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -35,7 +35,7 @@ func AddBaseRenderingOptions(f *flag.FlagSet, opts *templating.BaseRenderOptions
 
 	opts.Date = time.Now().UTC()
 	opts.OS = runtime.GOOS
-	// opts.Architecture = runtime.GOARCH // TODO: Not exposed yet.
+	opts.Architecture = runtime.GOARCH
 
 	// exec and render both use task and it's required, but build doesn't
 	if usesTask {

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -59,7 +59,7 @@ type BaseRenderOptions struct {
 	OS string
 
 	// Architecture is the GOARCH.
-	// Architecture string // TODO: Not exposed yet.
+	Architecture string
 }
 
 // OverrideValuesWithBuildInfo overrides the specified config's values and provides a default set of values.
@@ -79,7 +79,7 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 			"Date":         opts.Date.Format("20060102-150405z"), // yyyyMMdd-HHmmssz
 			"SharedVolume": opts.SharedVolume,
 			"OS":           opts.OS,
-			// "Arch": opts.Architecture, // TODO: Not exposed yet.
+			"Architecture": opts.Architecture,
 		},
 	}
 

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -129,7 +129,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	expectedGitTag := "some git tag"
 	expectedSharedVolume := "acb_home_vol_12345"
 	expectedOS := "linux"
-	// expectedArch := "amd64" // TODO: Not exposed yet.
+	expectedArchitecture := "amd64"
 
 	parsedTime, err := time.Parse("20060102-150405", "20100520-131422")
 	if err != nil {
@@ -149,7 +149,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		Date:         parsedTime,
 		SharedVolume: expectedSharedVolume,
 		OS:           expectedOS,
-		// Architecture: expectedArch, // TODO: Not exposed yet.
+		Architecture: expectedArchitecture,
 	}
 	vals, err := OverrideValuesWithBuildInfo(c1, c2, options)
 	if err != nil {
@@ -169,7 +169,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Run.Date}}", expectedTime},
 		{"{{.Run.SharedVolume}}", expectedSharedVolume},
 		{"{{.Run.OS}}", expectedOS},
-		// {"{{.Run.Architecture}}", expectedArch}, // TODO: Not exposed yet.
+		{"{{.Run.Architecture}}", expectedArchitecture},
 		{"{{.Values.born}}", eCurieBorn},
 		{"{{.Values.first}}", eCurieFirst},
 		{"{{.Values.last}}", eCurieLast},


### PR DESCRIPTION
**Purpose of the PR:**

Now that tasks and acb are deployed on Windows, I think it makes sense to expose `.Run.Architecture` so that you can have tasks that work cross-platform and reference different arch. IE: `windows/amd64` vs. `amd64`