### PR TITLE
Allow setting a Task's default working directory from CLI

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -35,8 +35,9 @@ type execCmd struct {
 	out    io.Writer
 	dryRun bool
 
-	registryUser string
-	registryPw   string
+	registryUser   string
+	registryPw     string
+	defaultWorkDir string
 
 	opts *templating.BaseRenderOptions
 }
@@ -59,6 +60,7 @@ func newExecCmd(out io.Writer) *cobra.Command {
 	f.StringVarP(&e.registryUser, "username", "u", "", "the username to use when logging into the registry")
 	f.StringVarP(&e.registryPw, "password", "p", "", "the password to use when logging into the registry")
 	f.BoolVar(&e.dryRun, "dry-run", false, "evaluates the task but doesn't execute it")
+	f.StringVar(&e.defaultWorkDir, "working-directory", "", "the default working directory to use if the underlying Task doesn't have one specified")
 
 	AddBaseRenderingOptions(f, e.opts, cmd, true)
 	return cmd
@@ -107,7 +109,7 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 		fmt.Println(rendered)
 	}
 
-	task, err := graph.UnmarshalTaskFromString(rendered, e.opts.Registry, e.registryUser, e.registryPw)
+	task, err := graph.UnmarshalTaskFromString(rendered, e.opts.Registry, e.registryUser, e.registryPw, e.defaultWorkDir)
 	if err != nil {
 		return err
 	}

--- a/graph/task.go
+++ b/graph/task.go
@@ -55,10 +55,13 @@ type Task struct {
 }
 
 // UnmarshalTaskFromString unmarshals a Task from a raw string.
-func UnmarshalTaskFromString(data, registry, user, pw string) (*Task, error) {
+func UnmarshalTaskFromString(data, registry, user, pw, defaultWorkDir string) (*Task, error) {
 	t := &Task{}
 	if err := yaml.Unmarshal([]byte(data), t); err != nil {
 		return t, errors.Wrap(err, "failed to deserialize task")
+	}
+	if defaultWorkDir != "" && t.WorkingDirectory == "" {
+		t.WorkingDirectory = defaultWorkDir
 	}
 	t.setRegistryInfo(registry, user, pw)
 	err := t.initialize()


### PR DESCRIPTION
**Purpose of the PR:**

- Allow setting a Task's default working directory from CLI instead of via yaml.

**Fixes #261**