### PR TITLE
fix golint path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   fast_finish: true
 
 install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck
   - go get github.com/kisielk/errcheck
   


### PR DESCRIPTION
Golint has been moved.

More info here -> https://github.com/golang/lint#installation and golang/lint#417