### PR TITLE
Add logs for when containers are being launched or fail

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -241,7 +241,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 	timeout := time.Duration(step.Timeout) * time.Second
 	stepCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	return b.procManager.RunWithRetries(stepCtx, args, nil, os.Stdout, os.Stderr, "", step.Retries, step.RetryDelayInSeconds)
+	return b.procManager.RunWithRetries(stepCtx, args, nil, os.Stdout, os.Stderr, "", step.Retries, step.RetryDelayInSeconds, step.ID)
 }
 
 // populateDigests populates digests on dependencies

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -40,14 +40,18 @@ func (pm *ProcManager) RunWithRetries(
 	stdErr io.Writer,
 	cmdDir string,
 	retries int,
-	retryDelay int) error {
+	retryDelay int,
+	containerName string) error {
 	attempt := 0
 	var err error
 	for attempt <= retries {
+		log.Printf("Launching container with name: %s\n...", containerName)
 		if err = pm.Run(ctx, args, stdIn, stdOut, stdErr, cmdDir); err == nil {
+			log.Printf("Successfully executed container: %s\n", containerName)
 			break
 		} else {
 			attempt++
+			log.Printf("Failed to launch container: %s, waiting %d seconds before retrying...\n", containerName, retryDelay)
 			time.Sleep(time.Duration(retryDelay) * time.Second)
 		}
 	}


### PR DESCRIPTION
**Purpose of the PR:**

- Add logs for when containers are being launched or fail to exit with a valid exit code.

**Fixes #334**