### PR TITLE
Add RegistryName as a base rendering option for templates

### DIFF
--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -76,6 +76,7 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 			"GitTag":       opts.GitTag,
 			"TriggeredBy":  opts.TriggeredBy,
 			"Registry":     opts.Registry,
+			"RegistryName": parseRegistryName(opts.Registry),
 			"Date":         opts.Date.Format("20060102-150405z"), // yyyyMMdd-HHmmssz
 			"SharedVolume": opts.SharedVolume,
 			"OS":           opts.OS,
@@ -155,4 +156,15 @@ func parseValues(values []string) (string, error) {
 	}
 
 	return ret.ToYAMLString()
+}
+
+// parseRegistryName parses the fully qualified registry name and extracts only the registry name.
+// NB: This function is currently designed and provided for Azure Container Registry and may not
+// work as expected for all other registries' formats.
+func parseRegistryName(fullyQualifiedRegistryName string) string {
+	idx := strings.Index(fullyQualifiedRegistryName, ".")
+	if idx < 0 {
+		return fullyQualifiedRegistryName
+	}
+	return fullyQualifiedRegistryName[:idx]
 }

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -51,3 +51,22 @@ func TestParseValues_Invalid(t *testing.T) {
 		}
 	}
 }
+
+func TestParseRegistryName(t *testing.T) {
+	tests := []struct {
+		fullyQualifiedRegistryName string
+		expectedRegistryName       string
+	}{
+		{"", ""},
+		{"foo", "foo"},
+		{"foo.azurecr.io", "foo"},
+		{"foo-bar.azurecr-test.io", "foo-bar"},
+		{"  ", "  "},
+	}
+
+	for _, test := range tests {
+		if actual := parseRegistryName(test.fullyQualifiedRegistryName); actual != test.expectedRegistryName {
+			t.Errorf("Expected %s but got %s for the registry name", test.expectedRegistryName, actual)
+		}
+	}
+}

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -126,6 +126,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	expectedBranch := "br"
 	expectedTrigger := "triggered from someone cool!!1"
 	expectedRegistry := "foo.azurecr.io"
+	expectedRegistryName := "foo"
 	expectedGitTag := "some git tag"
 	expectedSharedVolume := "acb_home_vol_12345"
 	expectedOS := "linux"
@@ -165,6 +166,7 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Run.Branch}}", expectedBranch},
 		{"{{.Run.TriggeredBy}}", expectedTrigger},
 		{"{{.Run.Registry}}", expectedRegistry},
+		{"{{.Run.RegistryName}}", expectedRegistryName},
 		{"{{.Run.GitTag}}", expectedGitTag},
 		{"{{.Run.Date}}", expectedTime},
 		{"{{.Run.SharedVolume}}", expectedSharedVolume},


### PR DESCRIPTION
**Purpose of the PR:**
- Add RegistryName as a base rendering option for templates

**Fixes #322**