### PR TITLE
Add a warning message to github contexts that don't contain .git

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -326,6 +326,7 @@ func getRepoDigest(jsonContent string, reference *image.Reference) string {
 }
 
 func validateDockerContext(context string) {
+	context = strings.ToLower(context)
 	if strings.Contains(context, "github") && !strings.Contains(context, ".git") {
 		log.Printf("WARNING: %s might not be valid context. Valid Git repositories should end with .git.\n", context)
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -198,6 +198,8 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 		dockerfile, dockerContext := parseDockerBuildCmd(step.Build)
 		volName := b.workspaceDir
 
+		validateDockerContext(dockerContext)
+
 		log.Println("Obtaining source code and scanning for dependencies...")
 		timeout := time.Duration(scrapeTimeoutInSec) * time.Second
 		scrapeCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -321,4 +323,10 @@ func getRepoDigest(jsonContent string, reference *image.Reference) string {
 		}
 	}
 	return ""
+}
+
+func validateDockerContext(context string) {
+	if strings.Contains(context, "github") && !strings.Contains(context, ".git") {
+		log.Printf("WARNING: %s might not be valid context. Valid Git repositories should end with .git.\n", context)
+	}
 }


### PR DESCRIPTION
**Purpose of the PR:**

- Add a warning message to github contexts that don't contain .git

**Fixes #321**