### PR TITLE
Allow steps to have an explicit pull property

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -65,3 +65,21 @@ func TestGetRepoDigest(t *testing.T) {
 		}
 	}
 }
+
+func TestParseImageNameFromArgs(t *testing.T) {
+	tests := []struct {
+		args     string
+		expected string
+	}{
+		{"bash", "bash"},
+		{"", ""},
+		{"bash echo hello world", "bash"},
+		{"foo bar > qux &", "foo"},
+		{"foo    ", "foo"},
+	}
+	for _, test := range tests {
+		if actual := parseImageNameFromArgs(test.args); actual != test.expected {
+			t.Errorf("Expected %s but got %s", test.expected, actual)
+		}
+	}
+}

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -32,6 +32,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		Network:             DefaultNetworkName,
 		Retries:             5,
 		RetryDelayInSeconds: 90,
+		Pull:                true,
 	}
 
 	cStep := &Step{

--- a/graph/step.go
+++ b/graph/step.go
@@ -54,6 +54,7 @@ type Step struct {
 	Retries                         int      `yaml:"retries"`
 	RetryDelayInSeconds             int      `yaml:"retryDelay"`
 	DisableWorkingDirectoryOverride bool     `yaml:"disableWorkingDirectoryOverride"`
+	Pull                            bool     `yaml:"pull"`
 
 	StartTime  time.Time
 	EndTime    time.Time
@@ -131,7 +132,8 @@ func (s *Step) Equals(t *Step) bool {
 		s.IgnoreErrors != t.IgnoreErrors ||
 		s.Retries != t.Retries ||
 		s.RetryDelayInSeconds != t.RetryDelayInSeconds ||
-		s.DisableWorkingDirectoryOverride != t.DisableWorkingDirectoryOverride {
+		s.DisableWorkingDirectoryOverride != t.DisableWorkingDirectoryOverride ||
+		s.Pull != t.Pull {
 		return false
 	}
 

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -190,6 +190,7 @@ func TestEquals(t *testing.T) {
 				Retries:                         5,
 				RetryDelayInSeconds:             3,
 				DisableWorkingDirectoryOverride: true,
+				Pull:                            true,
 			},
 			&Step{
 				ID:                              "a",
@@ -217,6 +218,7 @@ func TestEquals(t *testing.T) {
 				Retries:                         5,
 				RetryDelayInSeconds:             3,
 				DisableWorkingDirectoryOverride: true,
+				Pull:                            true,
 			},
 			true,
 		},

--- a/graph/testdata/acb.yaml
+++ b/graph/testdata/acb.yaml
@@ -20,6 +20,7 @@ steps:
     workingDirectory: pullDir
     retries: 5
     retryDelay: 90
+    pull: true
 
   - id: build-qux
     cmd: 'azure/images/acr-builder build -f Dockerfile https://github.com/ehotinger/qux --cache-from=ubuntu'

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -45,7 +45,7 @@ func (pm *ProcManager) RunWithRetries(
 	attempt := 0
 	var err error
 	for attempt <= retries {
-		log.Printf("Launching container with name: %s\n...", containerName)
+		log.Printf("Launching container with name: %s...\n", containerName)
 		if err = pm.Run(ctx, args, stdIn, stdOut, stdErr, cmdDir); err == nil {
 			log.Printf("Successfully executed container: %s\n", containerName)
 			break


### PR DESCRIPTION
**Purpose of the PR:**

- Allow steps to have an explicit `pull` property.
- Fix a small logging bug where `...` was placed after a newline.

**Fixes #319**