### PR TITLE
Use log everywhere instead of fmt to prevent interleaving

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -116,8 +116,8 @@ func (b *Builder) RunTask(ctx context.Context, task *graph.Task) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to unmarshal image dependencies")
 		}
-		fmt.Println("The following dependencies were found:")
-		fmt.Println(string(bytes))
+		log.Println("The following dependencies were found:")
+		log.Println("\n" + string(bytes))
 	}
 
 	return nil

--- a/builder/context.go
+++ b/builder/context.go
@@ -17,12 +17,11 @@ import (
 	"github.com/Azure/acr-builder/graph"
 	"github.com/Azure/acr-builder/pkg/image"
 	"github.com/Azure/acr-builder/util"
-
 	"github.com/google/uuid"
 )
 
 var (
-	dependenciesRE = regexp.MustCompile(`^(\[{"image.*?\])$`)
+	dependenciesRE = regexp.MustCompile(`(\[{"image.*?\])$`)
 )
 
 // getDockerRunArgs populates the args for running a Docker container.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Azure/acr-builder/templating"
 	"github.com/Azure/acr-builder/util"
 	"github.com/google/uuid"
-
 	"github.com/spf13/cobra"
 )
 
@@ -163,8 +162,8 @@ func (b *buildCmd) createBuildTask() (*graph.Task, error) {
 	}
 
 	if debug {
-		fmt.Println("Rendered template:")
-		fmt.Println(rendered)
+		log.Println("Rendered template:")
+		log.Println(rendered)
 	}
 
 	// After the template has rendered, we have to parse the tags again

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -110,8 +110,8 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if debug {
-		fmt.Println("Rendered template:")
-		fmt.Println(rendered)
+		log.Println("Rendered template:")
+		log.Println(rendered)
 	}
 
 	task, err := graph.UnmarshalTaskFromString(rendered, e.opts.Registry, e.registryUser, e.registryPw, e.defaultWorkDir, e.network, e.envs)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -5,8 +5,8 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"io"
+	"log"
 
 	"github.com/Azure/acr-builder/templating"
 	"github.com/spf13/cobra"
@@ -61,7 +61,7 @@ func (r *renderCmd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("Rendered template:")
-	fmt.Println(rendered)
+	log.Println("Rendered template:")
+	log.Println(rendered)
 	return nil
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -6,10 +6,9 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
-
 	"io"
+	"log"
+	"os"
 	"time"
 
 	"github.com/Azure/acr-builder/pkg/procmanager"
@@ -92,7 +91,7 @@ func (s *scanCmd) run(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to unmarshal image dependencies")
 	}
 
-	fmt.Println("Dependencies:")
-	fmt.Println(string(bytes))
+	log.Println("Dependencies:")
+	log.Println(string(bytes))
 	return nil
 }


### PR DESCRIPTION
**Purpose of the PR:**

- Use `log` instead of `fmt` everywhere to prevent interleaving.
- Update the regex for capturing the JSON dependencies to include the time.
- When outputting dependencies, add a newline before the JSON string so that it's still nicely formatted and readable, i.e. it'll look like this now with timestamps:

```
2018/12/04 18:40:32 The following dependencies were found:
2018/12/04 18:40:32 
- image:
    registry: acrbuilddemo.azurecr-test.io
    repository: build-ng
    tag: latest
    digest: sha256:4c7bc8bcf1e8cc7d8cf4b3d502631a55568cfc1111d2e47bce3c134e25859dd0
  runtime-dependency:
    registry: registry.hub.docker.com
    repository: library/nginx
    tag: 1.13.3-alpine
    digest: sha256:24a27241f0450b465f9e9deb30628c524aa81a1aa6936daa41ef7c4345515272
  buildtime-dependency:
  - registry: registry.hub.docker.com
    repository: library/node
    tag: 8-alpine
    digest: sha256:fa979a27cee3c8664a689e27e778b766af72da52920454160421854027374f09
  git:
    git-head-revision: c7e2f8cb0bb0f632d1e24cb14e72637e68b47433
```

**Fixes #274**