### PR TITLE
Allows steps to be repeated

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -250,7 +250,19 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 	timeout := time.Duration(step.Timeout) * time.Second
 	stepCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	return b.procManager.RunWithRetries(stepCtx, args, nil, os.Stdout, os.Stderr, "", step.Retries, step.RetryDelayInSeconds, step.ID)
+
+	return b.procManager.RunRepeatWithRetries(
+		stepCtx,
+		args,
+		nil,
+		os.Stdout,
+		os.Stderr,
+		"",
+		step.Retries,
+		step.RetryDelayInSeconds,
+		step.ID,
+		step.Repeat,
+		step.IgnoreErrors)
 }
 
 // populateDigests populates digests on dependencies

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -110,6 +110,7 @@ func TestDagCreation_ValidFile(t *testing.T) {
 		Network:             "host",
 		Envs:                []string{"foo=taskEnv"},
 		RetryDelayInSeconds: defaultStepRetryDelayInSeconds,
+		Repeat:              2,
 	}
 
 	dict := make(map[string]*Step)

--- a/graph/step.go
+++ b/graph/step.go
@@ -51,10 +51,13 @@ type Step struct {
 	Network                         string   `yaml:"network"`
 	Isolation                       string   `yaml:"isolation"`
 	IgnoreErrors                    bool     `yaml:"ignoreErrors"`
-	Retries                         int      `yaml:"retries"`
 	RetryDelayInSeconds             int      `yaml:"retryDelay"`
 	DisableWorkingDirectoryOverride bool     `yaml:"disableWorkingDirectoryOverride"`
 	Pull                            bool     `yaml:"pull"`
+	// Retries specifies how many times a Step will be retried if it fails after its initial execution.
+	Retries int `yaml:"retries"`
+	// Repeat specifies how many times a Step will be repeated after its initial execution.
+	Repeat int `yaml:"repeat"`
 
 	StartTime  time.Time
 	EndTime    time.Time
@@ -133,7 +136,8 @@ func (s *Step) Equals(t *Step) bool {
 		s.Retries != t.Retries ||
 		s.RetryDelayInSeconds != t.RetryDelayInSeconds ||
 		s.DisableWorkingDirectoryOverride != t.DisableWorkingDirectoryOverride ||
-		s.Pull != t.Pull {
+		s.Pull != t.Pull ||
+		s.Repeat != t.Repeat {
 		return false
 	}
 

--- a/graph/step.go
+++ b/graph/step.go
@@ -25,6 +25,8 @@ var (
 	errIDContainsSpace = errors.New("Step ID cannot contain spaces")
 	errInvalidDeps     = errors.New("Step cannot contain other IDs in when if the immediate execution token is specified")
 	errInvalidStepType = errors.New("Step must only contain a single build, cmd, or push property")
+	errInvalidRetries  = errors.New("Step must specify retries >= 0")
+	errInvalidRepeat   = errors.New("Step must specify repeat >= 0")
 )
 
 // Step is a step in the execution task.
@@ -79,6 +81,12 @@ func (s *Step) Validate() error {
 	}
 	if s.ID == "" {
 		return errMissingID
+	}
+	if s.Retries < 0 {
+		return errInvalidRetries
+	}
+	if s.Repeat < 0 {
+		return errInvalidRepeat
 	}
 	if (s.IsCmdStep() && s.IsPushStep()) || (s.IsCmdStep() && s.IsBuildStep()) || (s.IsBuildStep() && s.IsPushStep()) {
 		return errInvalidStepType

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -87,9 +87,25 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			&Step{
-				ID:    "a",
-				Build: "b",
-				Push:  []string{"c"},
+				ID:    "apple",
+				Build: "banana",
+				Push:  []string{"d"},
+			},
+			true,
+		},
+		{
+			&Step{
+				ID:     "repeat",
+				Build:  "b",
+				Repeat: -1,
+			},
+			true,
+		},
+		{
+			&Step{
+				ID:      "retries",
+				Build:   "b",
+				Retries: -1,
 			},
 			true,
 		},

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -191,6 +191,7 @@ func TestEquals(t *testing.T) {
 				RetryDelayInSeconds:             3,
 				DisableWorkingDirectoryOverride: true,
 				Pull:                            true,
+				Repeat:                          45,
 			},
 			&Step{
 				ID:                              "a",
@@ -219,6 +220,7 @@ func TestEquals(t *testing.T) {
 				RetryDelayInSeconds:             3,
 				DisableWorkingDirectoryOverride: true,
 				Pull:                            true,
+				Repeat:                          45,
 			},
 			true,
 		},

--- a/graph/testdata/acb.yaml
+++ b/graph/testdata/acb.yaml
@@ -62,6 +62,7 @@ steps:
     privileged: true
     user: root
     network: "host"
+    repeat: 2
 
 envs:
   - "foo=taskEnv"

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -31,6 +31,30 @@ func NewProcManager(dryRun bool) *ProcManager {
 	}
 }
 
+// RunRepeatWithRetries performs a Run multiple times with retries.
+// If an error occurs during the repetition, the last error will be returned.
+func (pm *ProcManager) RunRepeatWithRetries(
+	ctx context.Context,
+	args []string,
+	stdIn io.Reader,
+	stdOut io.Writer,
+	stdErr io.Writer,
+	cmdDir string,
+	retries int,
+	retryDelay int,
+	containerName string,
+	repeat int,
+	ignoreErrors bool) error {
+	var err error
+	for i := 0; i <= repeat; i++ {
+		innerErr := pm.RunWithRetries(ctx, args, stdIn, stdOut, stdErr, cmdDir, retries, retryDelay, containerName)
+		if innerErr != nil {
+			err = innerErr
+		}
+	}
+	return err
+}
+
 // RunWithRetries performs Run with retries.
 func (pm *ProcManager) RunWithRetries(
 	ctx context.Context,
@@ -45,14 +69,18 @@ func (pm *ProcManager) RunWithRetries(
 	attempt := 0
 	var err error
 	for attempt <= retries {
-		log.Printf("Launching container with name: %s...\n", containerName)
+		log.Printf("Launching container with name: %s\n", containerName)
 		if err = pm.Run(ctx, args, stdIn, stdOut, stdErr, cmdDir); err == nil {
 			log.Printf("Successfully executed container: %s\n", containerName)
 			break
 		} else {
 			attempt++
-			log.Printf("Failed to launch container: %s, waiting %d seconds before retrying...\n", containerName, retryDelay)
-			time.Sleep(time.Duration(retryDelay) * time.Second)
+			if attempt <= retries {
+				log.Printf("Container failed during run: %s, waiting %d seconds before retrying...\n", containerName, retryDelay)
+				time.Sleep(time.Duration(retryDelay) * time.Second)
+			} else {
+				log.Printf("Container failed during run: %s. No retries remaining.\n", containerName)
+			}
 		}
 	}
 	return err

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -53,7 +53,10 @@ func (pm *ProcManager) RunRepeatWithRetries(
 			aggErrors = append(aggErrors, innerErr)
 		}
 	}
-	return errors.New(aggErrors.String())
+	if len(aggErrors) > 0 {
+		return errors.New(aggErrors.String())
+	}
+	return nil
 }
 
 // RunWithRetries performs Run with retries.

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -5,6 +5,7 @@ package procmanager
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"os"
@@ -45,14 +46,14 @@ func (pm *ProcManager) RunRepeatWithRetries(
 	containerName string,
 	repeat int,
 	ignoreErrors bool) error {
-	var err error
+	var aggErrors util.Errors
 	for i := 0; i <= repeat; i++ {
 		innerErr := pm.RunWithRetries(ctx, args, stdIn, stdOut, stdErr, cmdDir, retries, retryDelay, containerName)
 		if innerErr != nil {
-			err = innerErr
+			aggErrors = append(aggErrors, innerErr)
 		}
 	}
-	return err
+	return errors.New(aggErrors.String())
 }
 
 // RunWithRetries performs Run with retries.


### PR DESCRIPTION
**Purpose of the PR:**
- Allows containers to be repeated after their initial execution. If multiple errors are encountered during the repetition, the last error will be recorded. If the step is marked as `ignoreErrors`, the final error will be ignored and the step will be marked successful.

- Fixes a bug where if a container fails to execute it will have its `retryDelay` invoked. Now we only sleep before the final failure.

**Fixes #320**