### PR TITLE
Upgrade Go version in Dockerfiles to 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS gobuild-base
+FROM golang:1.11.2-alpine AS gobuild-base
 RUN apk add --no-cache \
 	git \
 	make

--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -64,7 +64,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 # 1. The go lang for 1803 tag is not available.
 # 2. The image pulls 2.11.1 version of MinGit which has an issue with git submodules command. https://github.com/git-for-windows/git/issues/1007#issuecomment-384281260
 
-ENV GOLANG_VERSION 1.10.3
+ENV GOLANG_VERSION 1.11.2
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \


### PR DESCRIPTION
**Purpose of the PR:**

- Upgrade Go version in Dockerfiles to 1.11.2
