### PR TITLE
Differentiate between local and remote context for scanning

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -205,6 +205,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 		dockerfile, dockerContext := parseDockerBuildCmd(step.Build)
 		volName := b.workspaceDir
 
+		// Print out a warning message if a remote context doesn't appear to be valid, i.e. doesn't end with .git.
 		validateDockerContext(dockerContext)
 
 		log.Println("Obtaining source code and scanning for dependencies...")

--- a/builder/context.go
+++ b/builder/context.go
@@ -93,7 +93,15 @@ func (b *Builder) getDockerRunArgs(
 	return args
 }
 
-func (b *Builder) scrapeDependencies(ctx context.Context, volName string, stepWorkDir string, outputDir string, dockerfile string, context string, tags []string, buildArgs []string) ([]*image.Dependencies, error) {
+func (b *Builder) scrapeDependencies(
+	ctx context.Context,
+	volName string,
+	stepWorkDir string,
+	outputDir string,
+	dockerfile string,
+	context string,
+	tags []string,
+	buildArgs []string) ([]*image.Dependencies, error) {
 	containerName := fmt.Sprintf("acb_dep_scanner_%s", uuid.New())
 	args := []string{
 		"docker",

--- a/graph/task.go
+++ b/graph/task.go
@@ -56,8 +56,8 @@ func UnmarshalTaskFromString(data, registry, user, pw, defaultWorkDir, network s
 
 	t.Envs = envs
 
-	//External network parsed in from CLI will be set as default network, it will be used for any step if no network provide for them
-	//The external network is append at the end of the list of networks, later we will do reverse iteration to get this network
+	// External network parsed in from CLI will be set as default network, it will be used for any step if no network provide for them
+	// The external network is append at the end of the list of networks, later we will do reverse iteration to get this network
 	if network != "" {
 		externalNetwork := NewNetwork(network, false, "external", true, true)
 		t.Networks = append(t.Networks, externalNetwork)
@@ -232,13 +232,13 @@ func getNormalizedDockerImageNames(dockerImages []string, registry string) []str
 	return normalizedDockerImages
 }
 
-// the step's environment variables should override the task's default ones if provided
+// mergeEnvs merges the step's environment variables, overriding the task's default ones if provided.
 func mergeEnvs(stepEnvs []string, taskEnvs []string) ([]string, error) {
 	if len(taskEnvs) < 1 {
 		return stepEnvs, nil
 	}
 
-	//preprocess the comma case
+	// preprocess the comma case
 	var newTaskEnvs []string
 	for _, env := range taskEnvs {
 		newEnv := strings.Split(env, ",")
@@ -246,7 +246,7 @@ func mergeEnvs(stepEnvs []string, taskEnvs []string) ([]string, error) {
 	}
 
 	var stepmap = make(map[string]string)
-	//parse stepEnvs into a map
+	// parse stepEnvs into a map
 	for _, env := range stepEnvs {
 		pair := strings.SplitN(env, "=", 2)
 		if len(pair) != 2 {
@@ -256,7 +256,7 @@ func mergeEnvs(stepEnvs []string, taskEnvs []string) ([]string, error) {
 		stepmap[pair[0]] = pair[1]
 	}
 
-	//merge the unique taskEnvs into stepEnvs
+	// merge the unique taskEnvs into stepEnvs
 	for _, env := range newTaskEnvs {
 		pair := strings.SplitN(env, "=", 2)
 
@@ -265,7 +265,7 @@ func mergeEnvs(stepEnvs []string, taskEnvs []string) ([]string, error) {
 			return stepEnvs, err
 		}
 
-		//if the env has not been provided, add to step env
+		// if the env has not been provided, add to step env
 		if _, ok := stepmap[pair[0]]; !ok {
 			stepEnvs = append(stepEnvs, pair[0]+"="+pair[1])
 		}

--- a/graph/task_test.go
+++ b/graph/task_test.go
@@ -131,7 +131,7 @@ func TestMergingEnvs(t *testing.T) {
 		{"key1=val1,key2=val2", "key3=val3,key4=val4"},
 	}
 
-	//Expect: stepEnvs should overwrite envs that exist in taskEnvs
+	// stepEnvs should overwrite envs that exist in taskEnvs
 	expects := [][]string{
 		{"key1=val1", "key2=val2", "key3=val3"},
 		{"key1=newVal1", "key2=newVal2", "key3=val3"},

--- a/scan/dependencies.go
+++ b/scan/dependencies.go
@@ -30,7 +30,7 @@ var (
 // ScanForDependencies scans for base image dependencies.
 func (s *Scanner) ScanForDependencies(context string, workingDir string, dockerfile string, buildArgs []string, pushTo []string) (deps []*image.Dependencies, err error) {
 	dockerfilePath := dockerfile
-	// If the context is local, the Dockerfile path is simply the Dockerfi;e.
+	// If the context is local, the Dockerfile path is simply the Dockerfile.
 	// In the case of remote contexts, it's scoped to the clone or downloaded location and the working directory.
 	// For example, for a git URL ending with .git#:foo/bar which was downloaded to a directory "build",
 	// the path is scoped to build/foo/bar/Dockerfile.

--- a/scan/dependencies.go
+++ b/scan/dependencies.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/Azure/acr-builder/pkg/image"
+	"github.com/Azure/acr-builder/util"
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 )
@@ -27,11 +28,18 @@ var (
 )
 
 // ScanForDependencies scans for base image dependencies.
-func (s *Scanner) ScanForDependencies(workingDir string, dockerfile string, buildArgs []string, pushTo []string) (deps []*image.Dependencies, err error) {
-	path := path.Clean(path.Join(workingDir, dockerfile))
-	file, err := os.Open(path)
+func (s *Scanner) ScanForDependencies(context string, workingDir string, dockerfile string, buildArgs []string, pushTo []string) (deps []*image.Dependencies, err error) {
+	dockerfilePath := dockerfile
+	// If the context is local, the Dockerfile path is simply the Dockerfi;e.
+	// In the case of remote contexts, it's scoped to the clone or downloaded location and the working directory.
+	// For example, for a git URL ending with .git#:foo/bar which was downloaded to a directory "build",
+	// the path is scoped to build/foo/bar/Dockerfile.
+	if !util.IsLocalContext(s.context) {
+		dockerfilePath = path.Clean(path.Join(workingDir, dockerfile))
+	}
+	file, err := os.Open(dockerfilePath)
 	if err != nil {
-		return deps, fmt.Errorf("Error opening dockerfile: %s, error: %v", path, err)
+		return deps, fmt.Errorf("Error opening dockerfile: %s, error: %v", dockerfilePath, err)
 	}
 	defer func() { _ = file.Close() }()
 

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -51,7 +51,7 @@ func (s *Scanner) Scan(ctx context.Context) (deps []*image.Dependencies, err err
 		return deps, err
 	}
 
-	deps, err = s.ScanForDependencies(workingDir, s.dockerfile, s.buildArgs, s.tags)
+	deps, err = s.ScanForDependencies(s.context, workingDir, s.dockerfile, s.buildArgs, s.tags)
 	if err != nil {
 		return deps, err
 	}


### PR DESCRIPTION
**Purpose of the PR:**

- Differentiate between local and remote context during scanning to match Docker's behavior.
- Minor refactoring

**Fixes https://github.com/Azure/acr/issues/160**
**Fixes https://github.com/Azure/acr-builder/issues/286**