### PR TITLE
Allow passing Run/Values as JSON to containers

### DIFF
--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -95,11 +95,11 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 
 	valsJSON, err := json.Marshal(vals)
 	if err != nil {
-		return base, err
+		return base, errors.Wrap(err, "failed to serialize Values")
 	}
 	runJSON, err := json.Marshal(base["Run"])
 	if err != nil {
-		return base, err
+		return base, errors.Wrap(err, "failed to serialize Run")
 	}
 
 	base["Values"] = vals

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -104,3 +104,25 @@ func TestLoadAndRenderSteps(t *testing.T) {
 		t.Errorf("Expected \n%s\n but got \n%s\n", expected, actual)
 	}
 }
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		original string
+		expected string
+	}{
+		{"", "''"},
+		{`''`, `''"'"''"'"''`},
+		{`'single quotes'`, `''"'"'single quotes'"'"''`},
+		{"double quotes", "'double quotes'"},
+		{`no quotes`, `'no quotes'`},
+		{`{;$\}`, `'{;$\}'`},
+		{`nothingtoescape`, `nothingtoescape`},
+		{`{"val": "foo", "bar": "something#@$!()"}`, `'{"val": "foo", "bar": "something#@$!()"}'`},
+	}
+
+	for _, test := range tests {
+		if actual := shellQuote(test.original); actual != test.expected {
+			t.Fatalf("Expected %s but got %s", test.expected, actual)
+		}
+	}
+}

--- a/templating/testdata/curie/values.yaml
+++ b/templating/testdata/curie/values.yaml
@@ -5,8 +5,6 @@ research: radioactivity
 from: Poland
 
 awards:
-  - id: Nobel Prize in Physics
-
-  - id: Davy Medal
-
-  - id: Albert Medal
+  - Nobel Prize in Physics
+  - Davy Medal
+  - Albert Medal

--- a/templating/values_test.go
+++ b/templating/values_test.go
@@ -20,7 +20,7 @@ const (
 	eCurieBorn     = "1867"
 	eCurieResearch = "radioactivity"
 	eCurieFrom     = "Poland"
-	eCurieAwards   = "[map[id:Nobel Prize in Physics] map[id:Davy Medal] map[id:Albert Medal]]"
+	eCurieAwards   = "[Nobel Prize in Physics Davy Medal Albert Medal]"
 )
 
 // TestDeserialize tests deserialization of bytes to Values.
@@ -123,9 +123,9 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 
 	expectedID := "SomeID"
 	expectedCommit := "Some Commit"
-	expectedRepo := "some RePo"
+	expectedRepository := "some RePo"
 	expectedBranch := "br"
-	expectedTrigger := "triggered from someone cool!!1"
+	expectedTriggeredBy := "triggered from someone cool!!1"
 	expectedRegistry := "foo.azurecr.io"
 	expectedRegistryName := "foo"
 	expectedGitTag := "some git tag"
@@ -143,9 +143,9 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 	options := &BaseRenderOptions{
 		ID:           expectedID,
 		Commit:       expectedCommit,
-		Repository:   expectedRepo,
+		Repository:   expectedRepository,
 		Branch:       expectedBranch,
-		TriggeredBy:  expectedTrigger,
+		TriggeredBy:  expectedTriggeredBy,
 		Registry:     expectedRegistry,
 		GitTag:       expectedGitTag,
 		Date:         parsedTime,
@@ -163,9 +163,9 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Build.ID}}", expectedID},
 		{"{{.Run.ID}}", expectedID},
 		{"{{.Run.Commit}}", expectedCommit},
-		{"{{ .Run.Repository}}", expectedRepo},
+		{"{{ .Run.Repository}}", expectedRepository},
 		{"{{.Run.Branch}}", expectedBranch},
-		{"{{.Run.TriggeredBy}}", expectedTrigger},
+		{"{{.Run.TriggeredBy}}", expectedTriggeredBy},
 		{"{{.Run.Registry}}", expectedRegistry},
 		{"{{.Run.RegistryName}}", expectedRegistryName},
 		{"{{.Run.GitTag}}", expectedGitTag},
@@ -178,6 +178,24 @@ func TestOverrideValuesWithBuildInfo(t *testing.T) {
 		{"{{.Values.last}}", eCurieLast},
 		{"{{.Values.from}}", eCurieFrom},
 		{"{{.Values.awards }}", eCurieAwards},
+		{"{{.ValuesJSON}}", "'{\"awards\":[\"Nobel Prize in Physics\",\"Davy Medal\",\"Albert Medal\"]," +
+			"\"born\":" + eCurieBorn +
+			",\"first\":\"" + eCurieFirst +
+			"\",\"from\":\"" + eCurieFrom +
+			"\",\"last\":\"" + eCurieLast +
+			"\",\"research\":\"" + eCurieResearch + "\"}'"},
+		{"{{.RunJSON}}", "'{\"Architecture\":\"" + expectedArchitecture +
+			"\",\"Branch\":\"" + expectedBranch +
+			"\",\"Commit\":\"" + expectedCommit +
+			"\",\"Date\":\"" + expectedTime +
+			"\",\"GitTag\":\"" + expectedGitTag +
+			"\",\"ID\":\"" + expectedID +
+			"\",\"OS\":\"" + expectedOS +
+			"\",\"Registry\":\"" + expectedRegistry +
+			"\",\"RegistryName\":\"" + expectedRegistryName +
+			"\",\"Repository\":\"" + expectedRepository +
+			"\",\"SharedVolume\":\"" + expectedSharedVolume +
+			"\",\"TriggeredBy\":\"" + expectedTriggeredBy + "\"}'"},
 	}
 	for _, test := range tests {
 		if o, err := executeTemplate(test.tpl, vals); err != nil || o != test.expect {


### PR DESCRIPTION
**Purpose of the PR:**

- Allow passing Run/Values as JSON to containers.

There is one downside to this approach: since YAML can contain keys other than strings and JSON cannot, the default encoder can crash for complex objects, such as the Marie Curie example I've modified in this PR. This is well-discussed in the various yaml libraries and there are workarounds by either changing the default encoder from `map[interface{}]interface{}` to `map[string]interface{}`, or creating a custom recursive decoder. Since the yaml library that we're using is working on v3 with a possible design fix, I've opted to simply say we won't support these complex objects as a part of `--set` or `Values` for now. If it becomes a requirement we can either fork the library or create a custom decoder. Note: this will be a breaking change if anyone has self-discovered this undocumented functionality.