### PR TITLE
deprecate username/password

### DIFF
--- a/cmd/acb/build.go
+++ b/cmd/acb/build.go
@@ -79,7 +79,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 	f.StringArrayVar(&r.buildArgs, "build-arg", []string{}, "set build time arguments")
 	f.StringArrayVar(&r.secretBuildArgs, "secret-build-arg", []string{}, "set secret build arguments")
 	f.StringArrayVar(&r.labels, "label", []string{}, "set metadata for an image")
-	f.StringArrayVar(&r.credentials, "credentials", []string{}, "credentials passed on for Source registry plus any custom registries")
+	f.StringArrayVar(&r.credentials, "credentials", []string{}, "credentials passed on for source registry plus any custom registries")
 	f.StringVar(&r.isolation, "isolation", "", "the isolation to use")
 	f.StringVar(&r.target, "target", "", "specify a stage to build")
 	f.StringVar(&r.platform, "platform", "", "sets the platform if the server is capable of multiple platforms")

--- a/cmd/acb/build.go
+++ b/cmd/acb/build.go
@@ -82,8 +82,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 	f.StringArrayVar(&r.secretBuildArgs, "secret-build-arg", []string{}, "set secret build arguments")
 	f.StringArrayVar(&r.labels, "label", []string{}, "set metadata for an image")
 
-	// Runner never passed `username` and `password` now. Instead it adds it to `credentials` IFF passed.
-	// It should be safe to remove this from everywhere. But right now, it will just be always empty
+	// `username` and `password` are deprecated. Use --credentials="registryName;username;password" instead
 	f.StringVarP(&r.registryUser, "username", "u", "", "the username to use when logging into the registry")
 	f.StringVarP(&r.registryPw, "password", "p", "", "the password to use when logging into the registry")
 

--- a/cmd/acb/build.go
+++ b/cmd/acb/build.go
@@ -36,8 +36,6 @@ type buildCmd struct {
 	context         string
 	dockerfile      string
 	target          string
-	registryUser    string
-	registryPw      string
 	credentials     []string
 	isolation       string
 	platform        string
@@ -81,13 +79,7 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 	f.StringArrayVar(&r.buildArgs, "build-arg", []string{}, "set build time arguments")
 	f.StringArrayVar(&r.secretBuildArgs, "secret-build-arg", []string{}, "set secret build arguments")
 	f.StringArrayVar(&r.labels, "label", []string{}, "set metadata for an image")
-
-	// `username` and `password` are deprecated. Use --credentials="registryName;username;password" instead
-	f.StringVarP(&r.registryUser, "username", "u", "", "the username to use when logging into the registry")
-	f.StringVarP(&r.registryPw, "password", "p", "", "the password to use when logging into the registry")
-
 	f.StringArrayVar(&r.credentials, "credentials", []string{}, "credentials passed on for Source registry plus any custom registries")
-
 	f.StringVar(&r.isolation, "isolation", "", "the isolation to use")
 	f.StringVar(&r.target, "target", "", "specify a stage to build")
 	f.StringVar(&r.platform, "platform", "", "sets the platform if the server is capable of multiple platforms")
@@ -143,10 +135,6 @@ func (b *buildCmd) run(cmd *cobra.Command, args []string) error {
 
 func (b *buildCmd) validateCmdArgs() error {
 	if err := validateIsolation(b.isolation); err != nil {
-		return err
-	}
-
-	if err := validateRegistryCreds(b.registryUser, b.registryPw); err != nil {
 		return err
 	}
 

--- a/cmd/acb/build.go
+++ b/cmd/acb/build.go
@@ -82,9 +82,12 @@ func newBuildCmd(out io.Writer) *cobra.Command {
 	f.StringArrayVar(&r.secretBuildArgs, "secret-build-arg", []string{}, "set secret build arguments")
 	f.StringArrayVar(&r.labels, "label", []string{}, "set metadata for an image")
 
+	// Runner never passed `username` and `password` now. Instead it adds it to `credentials` IFF passed.
+	// It should be safe to remove this from everywhere. But right now, it will just be always empty
 	f.StringVarP(&r.registryUser, "username", "u", "", "the username to use when logging into the registry")
 	f.StringVarP(&r.registryPw, "password", "p", "", "the password to use when logging into the registry")
-	f.StringArrayVar(&r.credentials, "credentials", []string{}, "all credentials for private repos")
+
+	f.StringArrayVar(&r.credentials, "credentials", []string{}, "credentials passed on for Source registry plus any custom registries")
 
 	f.StringVar(&r.isolation, "isolation", "", "the isolation to use")
 	f.StringVar(&r.target, "target", "", "specify a stage to build")
@@ -148,7 +151,7 @@ func (b *buildCmd) validateCmdArgs() error {
 		return err
 	}
 
-	if err := validatePush(b.push, b.opts.Registry, b.registryUser, b.registryPw); err != nil {
+	if err := validatePush(b.push, b.credentials); err != nil {
 		return err
 	}
 

--- a/cmd/acb/build.go
+++ b/cmd/acb/build.go
@@ -198,16 +198,8 @@ func (b *buildCmd) createBuildTask() (*graph.Task, error) {
 	secrets := []*graph.Secret{}
 
 	var credentials []*graph.Credential
-	// If the user provides the username and password, add it to the Credentials
-	if b.opts.Registry != "" && b.registryUser != "" && b.registryPw != "" {
-		creds, err := graph.NewCredential(b.opts.Registry, b.registryUser, b.registryPw)
-		if err != nil {
-			return nil, err
-		}
-		credentials = append(credentials, creds)
-	}
 
-	// Add any additional creds provided by the user in the --credentials flag
+	// Add all creds provided by the user in the --credentials flag
 	for _, credString := range b.credentials {
 		// creds should be of the form of "regName;userName;password". If not, return an error
 		cred, err := graph.CreateCredentialFromString(credString)

--- a/cmd/acb/build_test.go
+++ b/cmd/acb/build_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"testing"
 
+	"github.com/Azure/acr-builder/graph"
 	"github.com/Azure/acr-builder/templating"
 	"github.com/Azure/acr-builder/util"
 )
@@ -27,6 +28,17 @@ func TestCreateBuildTask(t *testing.T) {
 	task, err := buildCmd.createBuildTask()
 	if err != nil {
 		t.Fatalf("failed to create build task, err: %v", err)
+	}
+	if len(task.Credentials) == 0 {
+		t.Fatalf("Expected to create credentials but no credentials were created")
+	}
+
+	taskCreds := task.Credentials[0]
+	expectedCreds, _ := graph.CreateCredentialFromString(buildCmd.credentials[0])
+	if taskCreds.RegistryName != expectedCreds.RegistryName ||
+		taskCreds.RegistryUsername != expectedCreds.RegistryUsername ||
+		taskCreds.RegistryPassword != expectedCreds.RegistryPassword {
+		t.Fatalf("expected %v Creds, got %v", expectedCreds, taskCreds)
 	}
 
 	numSteps := len(task.Steps)

--- a/cmd/acb/build_test.go
+++ b/cmd/acb/build_test.go
@@ -12,14 +12,13 @@ import (
 
 func TestCreateBuildTask(t *testing.T) {
 	buildCmd := &buildCmd{
-		dockerfile:   "HelloWorld/Dockerfile",
-		registryUser: "user",
-		registryPw:   "pw",
-		context:      "src",
-		tags:         []string{"foo:latest", "bar/qux"},
-		pull:         true,
-		noCache:      false,
-		dryRun:       true,
+		dockerfile:  "HelloWorld/Dockerfile",
+		credentials: []string{"foo.azurecr.io;user;pw"},
+		context:     "src",
+		tags:        []string{"foo:latest", "bar/qux"},
+		pull:        true,
+		noCache:     false,
+		dryRun:      true,
 		opts: &templating.BaseRenderOptions{
 			Registry: "foo.azurecr.io",
 		},

--- a/cmd/acb/exec.go
+++ b/cmd/acb/exec.go
@@ -35,8 +35,6 @@ type execCmd struct {
 	out    io.Writer
 	dryRun bool
 
-	registryUser   string
-	registryPw     string
 	credentials    []string
 	defaultWorkDir string
 	network        string
@@ -60,8 +58,6 @@ func newExecCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&e.registryUser, "username", "u", "", "the username to use when logging into the registry")
-	f.StringVarP(&e.registryPw, "password", "p", "", "the password to use when logging into the registry")
 	f.StringArrayVar(&e.credentials, "credentials", []string{}, "all credentials for private repos")
 
 	f.BoolVar(&e.dryRun, "dry-run", false, "evaluates the task but doesn't execute it")
@@ -118,16 +114,8 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	var credentials []*graph.Credential
-	// If the user provides the username and password, add it to the Credentials
-	if e.opts.Registry != "" && e.registryUser != "" && e.registryPw != "" {
-		cred, err := graph.NewCredential(e.opts.Registry, e.registryUser, e.registryPw)
-		if err != nil {
-			return err
-		}
-		credentials = append(credentials, cred)
-	}
 
-	// Add any additional creds provided by the user in the --credentials flag
+	// Add all creds provided by the user in the --credentials flag
 	for _, credString := range e.credentials {
 		// creds should be of the form of "regName;userName;password". If not, return an error
 		cred, err := graph.CreateCredentialFromString(credString)
@@ -158,7 +146,7 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 }
 
 func (e *execCmd) validateCmdArgs() error {
-	return validateRegistryCreds(e.registryUser, e.registryPw)
+	return nil
 }
 
 func (e *execCmd) setDefaultTaskFile() {

--- a/cmd/acb/exec.go
+++ b/cmd/acb/exec.go
@@ -58,7 +58,7 @@ func newExecCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringArrayVar(&e.credentials, "credentials", []string{}, "all credentials for private repos")
+	f.StringArrayVar(&e.credentials, "credentials", []string{}, "credentials passed on for source registry plus any custom registries")
 
 	f.BoolVar(&e.dryRun, "dry-run", false, "evaluates the task but doesn't execute it")
 	f.StringVar(&e.defaultWorkDir, "working-directory", "", "the default working directory to use if the underlying Task doesn't have one specified")
@@ -132,10 +132,6 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := e.validateCmdArgs(); err != nil {
-		return err
-	}
-
 	timeout := time.Duration(task.TotalTimeout) * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -143,10 +139,6 @@ func (e *execCmd) run(cmd *cobra.Command, args []string) error {
 	builder := builder.NewBuilder(procManager, debug, e.opts.SharedVolume)
 	defer builder.CleanTask(context.Background(), task)
 	return builder.RunTask(ctx, task)
-}
-
-func (e *execCmd) validateCmdArgs() error {
-	return nil
 }
 
 func (e *execCmd) setDefaultTaskFile() {

--- a/cmd/acb/validation.go
+++ b/cmd/acb/validation.go
@@ -24,7 +24,7 @@ func validateIsolation(isolation string) error {
 
 func validatePush(push bool, credentials []string) error {
 	if push && len(credentials) == 0 {
-		return errors.New("when specifying push, username, password, and registry are required")
+		return errors.New("when specifying push, at least one credential is required")
 	}
 	return nil
 }

--- a/cmd/acb/validation.go
+++ b/cmd/acb/validation.go
@@ -6,6 +6,8 @@ package main
 import (
 	"errors"
 	"fmt"
+
+	"github.com/Azure/acr-builder/graph"
 )
 
 var isolations = map[string]bool{
@@ -22,6 +24,7 @@ func validateIsolation(isolation string) error {
 	return nil
 }
 
+// TODO Need to remove this but right now, `username` and `password` are always empty.
 func validateRegistryCreds(username string, password string) error {
 	if (username == "" && password == "") || (username != "" && password != "") {
 		return nil
@@ -29,9 +32,14 @@ func validateRegistryCreds(username string, password string) error {
 	return errors.New("when specifying username and password, provide both or neither")
 }
 
-func validatePush(push bool, registry string, username string, password string) error {
-	if push && (username == "" || password == "" || registry == "") {
-		return errors.New("when specifying push, username, password, and registry are required")
+func validatePush(push bool, credentials []string) error {
+	if push {
+		if len(credentials) == 0 {
+			return errors.New("when specifying push, username, password, and registry are required")
+		}
+		if _, err := graph.CreateCredentialFromString(credentials[0]); err != nil {
+			return errors.New("when specifying push, username, password, and registry are required in proper format")
+		}
 	}
 	return nil
 }

--- a/cmd/acb/validation.go
+++ b/cmd/acb/validation.go
@@ -22,14 +22,6 @@ func validateIsolation(isolation string) error {
 	return nil
 }
 
-// TODO Need to remove this but right now, `username` and `password` are always empty.
-func validateRegistryCreds(username string, password string) error {
-	if (username == "" && password == "") || (username != "" && password != "") {
-		return nil
-	}
-	return errors.New("when specifying username and password, provide both or neither")
-}
-
 func validatePush(push bool, credentials []string) error {
 	if push && len(credentials) == 0 {
 		return errors.New("when specifying push, username, password, and registry are required")

--- a/cmd/acb/validation.go
+++ b/cmd/acb/validation.go
@@ -6,8 +6,6 @@ package main
 import (
 	"errors"
 	"fmt"
-
-	"github.com/Azure/acr-builder/graph"
 )
 
 var isolations = map[string]bool{
@@ -33,13 +31,8 @@ func validateRegistryCreds(username string, password string) error {
 }
 
 func validatePush(push bool, credentials []string) error {
-	if push {
-		if len(credentials) == 0 {
-			return errors.New("when specifying push, username, password, and registry are required")
-		}
-		if _, err := graph.CreateCredentialFromString(credentials[0]); err != nil {
-			return errors.New("when specifying push, username, password, and registry are required in proper format")
-		}
+	if push && len(credentials) == 0 {
+		return errors.New("when specifying push, username, password, and registry are required")
 	}
 	return nil
 }

--- a/cmd/acb/validation_test.go
+++ b/cmd/acb/validation_test.go
@@ -37,3 +37,15 @@ func TestValidatePush_Valid(t *testing.T) {
 		t.Errorf("All creds are provided, but received an error: %v", err)
 	}
 }
+
+func TestValidatePush_Invalid(t *testing.T) {
+	if err := validatePush(true, nil); err == nil {
+		t.Error("Invalid creds provided but no error was returned")
+	}
+}
+
+func TestValidatePush_Invalid2(t *testing.T) {
+	if err := validatePush(true, []string{}); err == nil {
+		t.Error("Invalid creds provided but no error was returned")
+	}
+}

--- a/cmd/acb/validation_test.go
+++ b/cmd/acb/validation_test.go
@@ -28,26 +28,6 @@ func TestValidateIsolation_Invalid(t *testing.T) {
 	}
 }
 
-func TestValidateRegistryCreds_Valid(t *testing.T) {
-	if err := validateRegistryCreds("", ""); err != nil {
-		t.Errorf("No creds passed, but received err: %v", err)
-	}
-
-	if err := validateRegistryCreds("foo", "bar"); err != nil {
-		t.Errorf("Username/password provided, but returned an err: %v", err)
-	}
-}
-
-func TestValidateRegistryCreds_Invalid(t *testing.T) {
-	if err := validateRegistryCreds("foo", ""); err == nil {
-		t.Error("Expected an error from a missing password")
-	}
-
-	if err := validateRegistryCreds("", "bar"); err == nil {
-		t.Error("Expected an error from a missing username")
-	}
-}
-
 func TestValidatePush_Valid(t *testing.T) {
 	if err := validatePush(false, []string{";bar;qux"}); err != nil {
 		t.Errorf("Credentials shouldn't be required unless push is specified. Err: %v", err)
@@ -55,11 +35,5 @@ func TestValidatePush_Valid(t *testing.T) {
 
 	if err := validatePush(true, []string{"foo;bar;qux"}); err != nil {
 		t.Errorf("All creds are provided, but received an error: %v", err)
-	}
-}
-
-func TestValidatePush_Invalid(t *testing.T) {
-	if err := validatePush(true, []string{";bar;qux"}); err == nil {
-		t.Error("Invalid creds provided but no error was returned")
 	}
 }

--- a/cmd/acb/validation_test.go
+++ b/cmd/acb/validation_test.go
@@ -49,17 +49,17 @@ func TestValidateRegistryCreds_Invalid(t *testing.T) {
 }
 
 func TestValidatePush_Valid(t *testing.T) {
-	if err := validatePush(false, "", "bar", "qux"); err != nil {
+	if err := validatePush(false, []string{";bar;qux"}); err != nil {
 		t.Errorf("Credentials shouldn't be required unless push is specified. Err: %v", err)
 	}
 
-	if err := validatePush(true, "foo", "bar", "qux"); err != nil {
+	if err := validatePush(true, []string{"foo;bar;qux"}); err != nil {
 		t.Errorf("All creds are provided, but received an error: %v", err)
 	}
 }
 
 func TestValidatePush_Invalid(t *testing.T) {
-	if err := validatePush(true, "", "bar", "qux"); err == nil {
+	if err := validatePush(true, []string{";bar;qux"}); err == nil {
 		t.Error("Invalid creds provided but no error was returned")
 	}
 }

--- a/graph/credential.go
+++ b/graph/credential.go
@@ -4,6 +4,7 @@
 package graph
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -51,4 +52,8 @@ func CreateCredentialFromString(str string) (*Credential, error) {
 	}
 
 	return NewCredential(strs[0], strs[1], strs[2])
+}
+
+func (c Credential) String() string {
+	return fmt.Sprintf("%s %s", c.RegistryName, c.RegistryUsername)
 }


### PR DESCRIPTION
**Purpose of the PR:**
When `push` flag is specified, the validation checks for source registry, username and password flags to be provided. But, since the `username` and `password` fields are stripped off by runner, and instead added to the `credentials`, we need to update the validation.

ALSO deprecates username/password

**Fixes #**
Update validation to check credential array instead of separate fields.