### PR TITLE
CLI: rename credentials to credential

### DIFF
--- a/cmd/acb/commands/build/build.go
+++ b/cmd/acb/commands/build/build.go
@@ -69,7 +69,7 @@ var Command = cli.Command{
 			Usage: "set metadata for an image",
 		},
 		cli.StringSliceFlag{
-			Name:  "credentials",
+			Name:  "credential",
 			Usage: "registry credentials in the format of 'server;username;password'",
 		},
 		cli.BoolFlag{
@@ -151,7 +151,7 @@ var Command = cli.Command{
 			buildArgs       = context.StringSlice("build-arg")
 			secretBuildArgs = context.StringSlice("secret-build-arg")
 			labels          = context.StringSlice("label")
-			creds           = context.StringSlice("credentials")
+			creds           = context.StringSlice("credential")
 			pull            = context.Bool("pull")
 			noCache         = context.Bool("no-cache")
 			push            = context.Bool("push")

--- a/cmd/acb/commands/exec/exec.go
+++ b/cmd/acb/commands/exec/exec.go
@@ -50,7 +50,7 @@ var Command = cli.Command{
 			Usage: "the default environment variables which are applied to each step (use --env multiple times or use commas: env1=val1,env2=val2)",
 		},
 		cli.StringSliceFlag{
-			Name:  "credentials",
+			Name:  "credential",
 			Usage: "registry credentials in the format of 'server;username;password'",
 		},
 		cli.BoolFlag{
@@ -116,7 +116,7 @@ var Command = cli.Command{
 			defaultWorkingDirectory = context.String("working-directory")
 			defaultNetwork          = context.String("network")
 			defaultEnvs             = context.StringSlice("env")
-			creds                   = context.StringSlice("credentials")
+			creds                   = context.StringSlice("credential")
 			dryRun                  = context.Bool("dry-run")
 			debug                   = context.Bool("debug")
 


### PR DESCRIPTION
**Purpose of the PR:**

- CLI: rename credentials to credential for pluralization consistency.

**Fixes #383**