### PR TITLE
Allow overriding docker-cli image and git-lfs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG DOCKER_CLI_BASE_IMAGE=docker:18.03.0-ce-git
+
 FROM golang:1.11.2-alpine AS gobuild-base
 RUN apk add --no-cache \
 	git \
@@ -8,11 +10,12 @@ WORKDIR /go/src/github.com/Azure/acr-builder
 COPY . .
 RUN make binaries && mv bin/acb /usr/bin/acb
 
-FROM docker:18.03.0-ce-git
+FROM ${DOCKER_CLI_BASE_IMAGE}
 
+ARG GIT_LFS_VERSION=2.5.2
 # disable prompt asking for credential
 ENV GIT_TERMINAL_PROMPT 0
-RUN mkdir -p git-lfs && wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v2.5.2/git-lfs-linux-amd64-v2.5.2.tar.gz | tar xz -C git-lfs; \
+RUN mkdir -p git-lfs && wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz | tar xz -C git-lfs; \
  	mv git-lfs/git-lfs /usr/bin/ && rm -rf git-lfs && git lfs install
 
 COPY --from=acb /usr/bin/acb /usr/bin/acb

--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -31,7 +31,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-ENV GIT_LFS_DOWNLOAD_URL https://github.com/git-lfs/git-lfs/releases/download/v2.5.2/git-lfs-windows-amd64-v2.5.2.zip
+ARG GIT_LFS_VERSION=2.5.2
+ENV GIT_LFS_DOWNLOAD_URL https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-amd64-v${GIT_LFS_VERSION}.zip
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_LFS_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_LFS_DOWNLOAD_URL -OutFile 'git-lfs.zip'; \

--- a/baseimages/docker-cli/Dockerfile
+++ b/baseimages/docker-cli/Dockerfile
@@ -1,7 +1,10 @@
 # Required.
 # docker build -f baseimages/docker-cli/Dockerfile -t docker .
-FROM docker:18.06.0-ce-git
+ARG DOCKER_CLI_BASE_IMAGE=docker:18.06.0-ce-git
+FROM ${DOCKER_CLI_BASE_IMAGE}
+
+ARG GIT_LFS_VERSION=2.5.2
 # disable prompt asking for credential
 ENV GIT_TERMINAL_PROMPT 0
-RUN mkdir -p git-lfs && wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v2.5.2/git-lfs-linux-amd64-v2.5.2.tar.gz | tar xz -C git-lfs; \
+RUN mkdir -p git-lfs && wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz | tar xz -C git-lfs; \
  	mv git-lfs/git-lfs /usr/bin/ && rm -rf git-lfs && git lfs install

--- a/baseimages/docker-cli/Windows.Dockerfile
+++ b/baseimages/docker-cli/Windows.Dockerfile
@@ -35,7 +35,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	Write-Host 'Complete.';
 
 # install git-lfs
-ENV GIT_LFS_DOWNLOAD_URL https://github.com/git-lfs/git-lfs/releases/download/v2.5.2/git-lfs-windows-amd64-v2.5.2.zip
+ARG GIT_LFS_VERSION=2.5.2
+ENV GIT_LFS_DOWNLOAD_URL https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-amd64-v${GIT_LFS_VERSION}.zip
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_LFS_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_LFS_DOWNLOAD_URL -OutFile 'git-lfs.zip'; \


### PR DESCRIPTION
**Purpose of the PR:**

Allow building from other (eg, moby) docker-cli image