### PR TITLE
allow overriding the default msi endpoint

### DIFF
--- a/vaults/azurekeyvault.go
+++ b/vaults/azurekeyvault.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// environment variable to override the default msi endpoint
-	envAcrMsiEndpoint = "ACR_MSI_ENDPOINT"
+	envMsiEndpoint = "MSI_ENDPOINT"
 )
 
 // AKVSecretConfig provides the options to get secret from Azure keyvault using MSI.
@@ -156,8 +156,8 @@ func newAuthorizer(mc *auth.MSIConfig) (autorest.Authorizer, error) {
 	msiEndpoint := "http://169.254.169.254/metadata/identity/oauth2/token"
 
 	// override the default from environment variable
-	if acrMSIEndpoint := os.Getenv(envAcrMsiEndpoint); acrMSIEndpoint != "" {
-		msiEndpoint = acrMSIEndpoint
+	if endpoint := os.Getenv(envMsiEndpoint); endpoint != "" {
+		msiEndpoint = endpoint
 	}
 
 	var spToken *adal.ServicePrincipalToken

--- a/vaults/azurekeyvault.go
+++ b/vaults/azurekeyvault.go
@@ -149,7 +149,7 @@ func (k *keyVault) getSecret(ctx context.Context, secretName, secretVersion stri
 	return *secretBundle.Value, nil
 }
 
-// newAuthorizer creates the authorizer for kev vault client.
+// newAuthorizer creates the authorizer for keyvault client.
 // it is based on github.com/Azure/acr-builder/vendor/github.com/Azure/go-autorest/autorest/azure/auth/auth.go and allows overriding the msi endpont using environment variable
 func newAuthorizer(mc *auth.MSIConfig) (autorest.Authorizer, error) {
 	// default to the well known endpoint for getting MSI authentications tokens


### PR DESCRIPTION
**Purpose of the PR:**
Windows container handles 169.254.169.254 as local-link address and only route to on-link device by default. As the limitation, to allow acb talks to the msi token server on a different address, the change introduces a environment variable to override the default endpoint. 
