### PR TITLE
Start validating version

### DIFF
--- a/graph/task.go
+++ b/graph/task.go
@@ -24,6 +24,16 @@ const (
 
 	// The default step retry delay is 5 seconds.
 	defaultStepRetryDelayInSeconds = 5
+
+	// currentTaskVersion is the most recent Task version.
+	currentTaskVersion = "v1.0.0"
+)
+
+var (
+	validTaskVersions = map[string]bool{
+		"1.0-preview-1":    true,
+		currentTaskVersion: true,
+	}
 )
 
 // Task represents a task execution.
@@ -145,6 +155,14 @@ func (t *Task) initialize() error {
 	newDefaultNetworkName := DefaultNetworkName
 	addDefaultNetworkToSteps := false
 
+	if t.Version == "" {
+		t.Version = currentTaskVersion
+	}
+
+	if err := validateTaskVersion(t.Version); err != nil {
+		return err
+	}
+
 	// Reverse iterate the list to get the default network
 	for i := len(t.Networks) - 1; i >= 0; i-- {
 		network := t.Networks[i]
@@ -195,7 +213,7 @@ func (t *Task) initialize() error {
 
 		newEnvs, err := mergeEnvs(s.Envs, t.Envs)
 		if err != nil {
-			return fmt.Errorf("bad format of environment variables, err: %v", err)
+			return errors.Wrap(err, "invalid environment variable format")
 		}
 		s.Envs = newEnvs
 
@@ -298,4 +316,13 @@ func mergeEnvs(stepEnvs []string, taskEnvs []string) ([]string, error) {
 	}
 
 	return stepEnvs, nil
+}
+
+// validateTaskVersion returns an error if the version specified within a Task is invalid.
+func validateTaskVersion(version string) error {
+	vLower := strings.ToLower(version)
+	if _, ok := validTaskVersions[vLower]; !ok {
+		return fmt.Errorf("invalid version specified: %s", version)
+	}
+	return nil
 }


### PR DESCRIPTION
**Purpose of the PR:**
Start validating/enforcing the version attribute on a Task.

There are currently two valid values:
- v1.0.0 (default)
- [1.0-preview-1](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-tasks-multi-step)

**Fixes #397**