### PR TITLE
Make network name required

### DIFF
--- a/graph/network.go
+++ b/graph/network.go
@@ -8,11 +8,16 @@ import (
 	"context"
 
 	"github.com/Azure/acr-builder/pkg/procmanager"
+	"github.com/pkg/errors"
 )
 
 const (
 	// DefaultNetworkName is the default network name.
 	DefaultNetworkName = "acb_default_network"
+)
+
+var (
+	errInvalidName = errors.New("name must be specified")
 )
 
 // Network defines a Docker network.
@@ -25,14 +30,17 @@ type Network struct {
 }
 
 // NewNetwork creates a new network.
-func NewNetwork(name string, ipv6 bool, driver string, skipCreation bool, isDefault bool) *Network {
+func NewNetwork(name string, ipv6 bool, driver string, skipCreation bool, isDefault bool) (*Network, error) {
+	if name == "" {
+		return nil, errInvalidName
+	}
 	return &Network{
 		Name:         name,
 		Ipv6:         ipv6,
 		Driver:       driver,
 		SkipCreation: skipCreation,
 		IsDefault:    isDefault,
-	}
+	}, nil
 }
 
 // Create creates a new Docker network.

--- a/graph/task.go
+++ b/graph/task.go
@@ -58,7 +58,11 @@ func UnmarshalTaskFromString(data string, defaultWorkDir string, network string,
 	// External network parsed in from CLI will be set as default network, it will be used for any step if no network provide for them
 	// The external network is append at the end of the list of networks, later we will do reverse iteration to get this network
 	if network != "" {
-		externalNetwork := NewNetwork(network, false, "external", true, true)
+		var externalNetwork *Network
+		externalNetwork, err = NewNetwork(network, false, "external", true, true)
+		if err != nil {
+			return t, err
+		}
 		t.Networks = append(t.Networks, externalNetwork)
 	}
 
@@ -158,7 +162,10 @@ func (t *Task) initialize() error {
 	// Add the default network if none are specified.
 	// Only add the default network if we're using tasks.
 	if !t.IsBuildTask && len(t.Networks) == 0 {
-		defaultNetwork := NewNetwork(newDefaultNetworkName, false, "bridge", false, true)
+		defaultNetwork, err := NewNetwork(newDefaultNetworkName, false, "bridge", false, true)
+		if err != nil {
+			return err
+		}
 		if runtime.GOOS == windowsOS {
 			defaultNetwork.Driver = "nat"
 		}


### PR DESCRIPTION
**Purpose of the PR:**
- Make network name required. It'll error without a name and we just weren't doing any validation before.