### PR TITLE
Update template docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ ACR Builder is the backbone behind [Azure Container Registry Tasks](https://docs
 
 It can be used to automate container image patching and execute arbitrary containers for complex workflows.
 
-You can find examples of how to create multi-step tasks [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-tasks-multi-step) and a reference to all of the available YAML properties [here](./docs/task.md).
+You can find examples of how to create multi-step tasks [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-tasks-multi-step).
+
+## Task Schema
+
+For a list of all available YAML properties, please review the [Task schema](./docs/task.md).
+
+## Templating
+
+To understand templating and how to provide custom values to your runs, review [templates](./docs/templates.md).
 
 ## Requirements
 
 - Docker
-- There are also dependency images that are used throughout the task. Refer to the `baseimages` folder for corresponding Dockerfiles to generate these images, and review the list below for Linux/Windows.
 
 ## Building
 
@@ -29,38 +36,33 @@ Windows:
 $ docker build -f Windows.Dockerfile -t acb .
 ```
 
-## Linux Images
-
-- `acb`
-- `docker`
-- `ubuntu`
-
-## Windows Images
-
-- `acb`
-- `docker`
-- `microsoft/windowsservercore:1803`
-
 ## Usage
 
 ```sh
 $ acb --help
 
-Usage:
-  acb [command]
+NAME:
+   acb - run and build containers on Azure Container Registry
 
-Available Commands:
-  build       Run a build
-  download    Download the specified context to a destination folder
-  exec        Execute a task
-  help        Help about any command
-  render      Render a template
-  scan        Scan a Dockerfile
-  version     Print version information
+USAGE:
+   acb [global options] command [command options] [arguments...]
 
-Flags:
-  -d, --debug   enable verbose output for debugging
-  -h, --help    help for acb
+VERSION:
+   38f06e5
+
+COMMANDS:
+     build      build container images
+     download   download the specified context to a destination folder
+     exec       execute a task file
+     render     render the specified template
+     scan       scan a Dockerfile for dependencies
+     version    print the client and runtime versions
+     getsecret  gets the secret value from a specified vault
+     help, h    Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h     show help
+   --version, -v  print the version
 ```
 
 ## Building an image

--- a/cmd/acb/commands/getsecret/getsecret.go
+++ b/cmd/acb/commands/getsecret/getsecret.go
@@ -24,7 +24,7 @@ var (
 // Command fetches secret from supported vaults displays the secret vaule as output.
 var Command = cli.Command{
 	Name:  "getsecret",
-	Usage: "gets the secret value from a specified vault.",
+	Usage: "gets the secret value from a specified vault",
 	Subcommands: []cli.Command{
 		{
 			Name:  "akv",

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,10 +1,12 @@
 # Templates
 
-Individual builds and tasks both support templating. Internally we use [Go templates](https://golang.org/pkg/text/template/) and [Sprig](https://github.com/Masterminds/sprig/).
+Both builds (`acb build`, `az acr build`) and tasks (`acb exec`, `az acr run -f acb.yaml`) support templating when running the builder locally. However, if the builder is invoked through Azure, only tasks support value-based templating. Builds can only render [run variables](#run-variables).
 
-## Using custom values
+Internally we use [Go templates](https://golang.org/pkg/text/template/) and [Sprig](https://github.com/Masterminds/sprig/) to perform the rendering. Please review their documentation for a list of all the available template functions.
 
-A sample values file looks like this:
+## Custom values
+
+A `values.yaml` file consists of key/value pairs, such as:
 
 ```yaml
 born: 1867
@@ -14,41 +16,20 @@ research: radioactivity
 from: Poland
 ```
 
-When this file is loaded with `--values`, you can reference any of the values using this syntax: `{{ .Values.born }}`, `{{ .Values.research }}`, etc.
-You could also override any of these values using `--set born=1900` for example.
+When this file is provided via `--values`, you can reference any of the values using `{{ .Values.born }}`, `{{ .Values.research }}`, etc.
 
-## Build variables
+You can override any of these values using `--set key=value`. For example, using `--set born=1900` would cause `{{.Values.born}}` to render as `1900`.
+
+## Run variables
 
 The following variables can be accessed using `{{ .Run.VariableName }}`, where `VariableName` equals one of the following:
 
-- `ID`
-- `SharedVolume`
-- `Registry` (the fully qualified registry name)
-- `RegistryName` (just the name of the registry)
-- `Date` (`yyyyMMdd-HHmmssz` format)
-- `OS`
-- `Architecture`
-
-## Tasks
-
-You can execute a task with `exec`. It requires a `-f` file and optionally a `--values` file. You can also use `--set` to override values specified in `--values`, or to provide new values not covered by `--values`.
-
-```sh
-$ acb exec -f templating/testdata/helloworld/git-build.yaml --values templating/testdata/helloworld/values.yaml --id demo
-
-...
-
-Successfully tagged acr-builder:demo
-```
-
-## Build
-
-Templating in `build` works the same as `exec`, except that you don't have to provide a `Task` file.
-
-```sh
-$ acb build https://github.com/Azure/acr-builder.git -f Dockerfile -t "acr-builder:{{.Run.ID}}" --id demo
-
-...
-
-Successfully tagged acr-builder:demo
-```
+| Variable Name | Description |
+|---------------|-------------|
+| `ID` | The unique identifier of the run |
+| `SharedVolume` | The unique identifier of the shared volume, which is accessible by all steps |
+| `Registry` | The fully qualified registry name |
+| `RegistryName` | The name of the container registry |
+| `Date` | The start time of the run in `yyyyMMdd-HHmmssz` format |
+| `OS` | The operating system being used |
+| `Architecture` | The architecture being used |


### PR DESCRIPTION
**Purpose of the PR:**
- Update template docs to indicate that `az acr build` doesn't support value-based templating but `az acr run` does.