### PR TITLE
log commitID and branch information

### DIFF
--- a/cmd/acb/commands/download/download.go
+++ b/cmd/acb/commands/download/download.go
@@ -5,6 +5,7 @@ package download
 
 import (
 	gocontext "context"
+	"encoding/json"
 	"errors"
 	"log"
 	"time"
@@ -13,6 +14,11 @@ import (
 	"github.com/Azure/acr-builder/scan"
 	"github.com/urfave/cli"
 )
+
+type gitInfo struct {
+	CommitID string `json:"commitID"`
+	Branch   string `json:"branch"`
+}
 
 // Command downloads the specified context to a destination folder.
 var Command = cli.Command{
@@ -55,12 +61,21 @@ var Command = cli.Command{
 		if err != nil {
 			return err
 		}
-		workingDir, _, err := scanner.ObtainSourceCode(ctx, downloadCtx)
+		workingDir, sha, branch, err := scanner.ObtainSourceCode(ctx, downloadCtx)
+		if err != nil {
+			return err
+		}
+
+		commitAndBranch, err := json.Marshal(&gitInfo{
+			CommitID: sha,
+			Branch:   branch,
+		})
 		if err != nil {
 			return err
 		}
 
 		log.Printf("Download complete, working directory: %s\n", workingDir)
+		log.Printf("CommitID and Branch information: %s\n", commitAndBranch)
 		return nil
 	},
 }

--- a/scan/context.go
+++ b/scan/context.go
@@ -29,17 +29,21 @@ const (
 )
 
 // ObtainSourceCode obtains the source code from the specified context.
-func (s *Scanner) ObtainSourceCode(ctx context.Context, scContext string) (workingDir string, sha string, err error) {
+func (s *Scanner) ObtainSourceCode(ctx context.Context, scContext string) (workingDir string, sha string, branch string, err error) {
 	isGitURL, workingDir, err := s.getContext(scContext)
 	if err != nil {
-		return workingDir, sha, err
+		return workingDir, sha, branch, err
 	}
 
 	if isGitURL {
 		sha, err = s.GetGitCommitID(ctx, workingDir)
+		if err != nil {
+			return workingDir, sha, branch, err
+		}
+		branch, err = s.GetGitBranchName(ctx, workingDir)
 	}
 
-	return workingDir, sha, err
+	return workingDir, sha, branch, err
 }
 
 func (s *Scanner) getContext(scContext string) (isGitURL bool, workingDir string, err error) {

--- a/scan/git.go
+++ b/scan/git.go
@@ -36,6 +36,18 @@ func (s *Scanner) GetGitCommitID(ctx context.Context, cmdDir string) (string, er
 	return strings.TrimSpace(buf.String()), nil
 }
 
+// GetGitBranchName queries git for the current branch name.
+// If a branch is checked out i.e. git checkout branch_name, then the following command will give `branch_name` as output
+// If a commit is checked out and head is at a detached state, then `HEAD` will be output.
+func (s *Scanner) GetGitBranchName(ctx context.Context, cmdDir string) (string, error) {
+	cmd := []string{"git", "rev-parse", "--abbrev-ref", "HEAD"}
+	var buf bytes.Buffer
+	if err := s.procManager.Run(ctx, cmd, nil, &buf, os.Stderr, cmdDir); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
 // Clone clones a repository into a newly created directory, returning the resulting directory name.
 func Clone(remoteURL string, root string) (string, error) {
 	repo, err := parseRemoteURL(remoteURL)

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -45,7 +45,7 @@ func NewScanner(pm *procmanager.ProcManager, sourceContext string, dockerfile st
 
 // Scan scans a Dockerfile for dependencies.
 func (s *Scanner) Scan(ctx context.Context) (deps []*image.Dependencies, err error) {
-	workingDir, sha, err := s.ObtainSourceCode(ctx, s.context)
+	workingDir, sha, _, err := s.ObtainSourceCode(ctx, s.context)
 	if err != nil {
 		return deps, errors.Wrap(err, "failed to download source code")
 	}


### PR DESCRIPTION
**Purpose of the PR:**
In the download.go, we fetch `CommitID` and `Branch` information of the Git context.
And we log it. 

Reason behind logging it is, it can be fetched by the STDOUT buffers for the client to fetch Git commit,branch information.

**Fixes #**