### PR TITLE
add support for working-directory for local build context

### DIFF
--- a/cmd/acb/commands/build/build.go
+++ b/cmd/acb/commands/build/build.go
@@ -41,6 +41,10 @@ var Command = cli.Command{
 			Value: "Dockerfile",
 		},
 		cli.StringFlag{
+			Name:  "working-directory",
+			Usage: "the default working directory to use",
+		},
+		cli.StringFlag{
 			Name:  "target",
 			Usage: "specifies the target stage to build in a multi-stage build",
 		},
@@ -142,21 +146,22 @@ var Command = cli.Command{
 	Action: func(context *cli.Context) error {
 		var (
 			// Build options
-			buildContext    = context.Args().First()
-			dockerfile      = context.String("file")
-			target          = context.String("target")
-			isolation       = context.String("isolation")
-			platform        = context.String("platform")
-			tags            = context.StringSlice("tag")
-			buildArgs       = context.StringSlice("build-arg")
-			secretBuildArgs = context.StringSlice("secret-build-arg")
-			labels          = context.StringSlice("label")
-			creds           = context.StringSlice("credential")
-			pull            = context.Bool("pull")
-			noCache         = context.Bool("no-cache")
-			push            = context.Bool("push")
-			dryRun          = context.Bool("dry-run")
-			debug           = context.Bool("debug")
+			buildContext            = context.Args().First()
+			dockerfile              = context.String("file")
+			defaultWorkingDirectory = context.String("working-directory")
+			target                  = context.String("target")
+			isolation               = context.String("isolation")
+			platform                = context.String("platform")
+			tags                    = context.StringSlice("tag")
+			buildArgs               = context.StringSlice("build-arg")
+			secretBuildArgs         = context.StringSlice("secret-build-arg")
+			labels                  = context.StringSlice("label")
+			creds                   = context.StringSlice("credential")
+			pull                    = context.Bool("pull")
+			noCache                 = context.Bool("no-cache")
+			push                    = context.Bool("push")
+			dryRun                  = context.Bool("dry-run")
+			debug                   = context.Bool("debug")
 
 			// Rendering options
 			values        = context.String("values")
@@ -233,7 +238,8 @@ var Command = cli.Command{
 			debug,
 			registry,
 			push,
-			creds)
+			creds,
+			defaultWorkingDirectory)
 		if err != nil {
 			return err
 		}
@@ -262,6 +268,7 @@ func createBuildTask(
 	registry string,
 	push bool,
 	creds []string,
+	workingDirectory string,
 ) (*graph.Task, error) {
 	// Create the run command to be used in the template
 	args := []string{}
@@ -344,5 +351,5 @@ func createBuildTask(
 		credentials = append(credentials, cred)
 	}
 
-	return graph.NewTask(ctx, steps, []*secretmgmt.Secret{}, registry, credentials, true)
+	return graph.NewTask(ctx, steps, []*secretmgmt.Secret{}, registry, credentials, true, workingDirectory)
 }

--- a/cmd/acb/commands/build/build_test.go
+++ b/cmd/acb/commands/build/build_test.go
@@ -29,9 +29,10 @@ func TestCreateBuildTask(t *testing.T) {
 		renderOpts      = &templating.BaseRenderOptions{
 			Registry: registry,
 		}
-		debug = false
-		push  = true
-		creds = []string{`{"registry":"foo.azurecr.io","username":"user","userNameProviderType":"opaque","password":"pw","passwordProviderType":"opaque"}`}
+		debug      = false
+		push       = true
+		creds      = []string{`{"registry":"foo.azurecr.io","username":"user","userNameProviderType":"opaque","password":"pw","passwordProviderType":"opaque"}`}
+		workingDir = ""
 	)
 
 	task, err := createBuildTask(
@@ -51,7 +52,8 @@ func TestCreateBuildTask(t *testing.T) {
 		debug,
 		registry,
 		push,
-		creds)
+		creds,
+		workingDir)
 	if err != nil {
 		t.Fatalf("failed to create build task, err: %v", err)
 	}

--- a/graph/task.go
+++ b/graph/task.go
@@ -148,7 +148,8 @@ func NewTask(
 	secrets []*secretmgmt.Secret,
 	registry string,
 	credentials []*RegistryCredential,
-	isBuildTask bool) (*Task, error) {
+	isBuildTask bool,
+	defaultWorkDir string) (*Task, error) {
 	t := &Task{
 		Steps:        steps,
 		StepTimeout:  defaultStepTimeoutInSeconds,
@@ -157,7 +158,9 @@ func NewTask(
 		Credentials:  credentials,
 		IsBuildTask:  isBuildTask,
 	}
-
+	if defaultWorkDir != "" && t.WorkingDirectory == "" {
+		t.WorkingDirectory = defaultWorkDir
+	}
 	err := t.initialize(ctx)
 	return t, err
 }

--- a/graph/task_test.go
+++ b/graph/task_test.go
@@ -77,7 +77,7 @@ func TestNewTask(t *testing.T) {
 			}
 		}
 
-		task, err := NewTask(gocontext.Background(), test.steps, test.secrets, test.registry, []*RegistryCredential{cred}, test.isBuildTask)
+		task, err := NewTask(gocontext.Background(), test.steps, test.secrets, test.registry, []*RegistryCredential{cred}, test.isBuildTask, "")
 		if err != nil {
 			t.Fatalf("Unexpected err while creating task: %v", err)
 		}


### PR DESCRIPTION
Allows passing in `working-directory` flag to build. This is to support building local context.