### PR TITLE
Update linter to 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - "1.12.x"
+  - "1.12.1"
   
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clean: ## Clean up all binaries
 .PHONY: lint
 lint: ## Run all linters
 	@echo "+ $@"
-	golangci-lint run
+	@golangci-lint run
 
 .PHONY: coverage
 coverage: ## Runs coverage tests and generates a report

--- a/scripts/setup/dev_setup
+++ b/scripts/setup/dev_setup
@@ -3,4 +3,4 @@
 set -e -o pipefail
 
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0


### PR DESCRIPTION
**Purpose of the PR:**

- Update linter to 1.16
- Looks like Go 1.12.2 has broken us, so I'm hardcoding it to 1.12.1 for now.
- Prevents echoing the golang-ci command