### PR TITLE
Update scanner to allow default Dockerfile path

### DIFF
--- a/builder/context.go
+++ b/builder/context.go
@@ -172,7 +172,6 @@ func getScanArgs(
 
 	// Positional context must appear last
 	args = append(args, sourceContext)
-
 	return args
 }
 

--- a/builder/context_test.go
+++ b/builder/context_test.go
@@ -162,19 +162,20 @@ func TestGetScanArgs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := strings.Join(getScanArgs(
-			test.containerName,
-			test.volName,
-			test.containerWorkspaceDir,
-			test.stepWorkDir,
-			test.dockerfile,
-			test.outputDir,
-			test.tags,
-			test.buildArgs,
-			test.context), " ")
+		actual := strings.Join(
+			getScanArgs(
+				test.containerName,
+				test.volName,
+				test.containerWorkspaceDir,
+				test.stepWorkDir,
+				test.dockerfile,
+				test.outputDir,
+				test.tags,
+				test.buildArgs,
+				test.context),
+			" ")
 		if test.expected != actual {
-			t.Fatalf("Expected %s but got %s", test.expected, actual)
+			t.Fatalf("Expected\n%s\nbut got\n%s", test.expected, actual)
 		}
-
 	}
 }

--- a/builder/parse.go
+++ b/builder/parse.go
@@ -21,7 +21,7 @@ const (
 func parseDockerBuildCmd(cmd string) (dockerfile string, context string) {
 	fields := strings.Fields(cmd)
 	prev := ""
-	dockerfile = "Dockerfile"
+	dockerfile = ""
 	context = "."
 
 	for i := 0; i < len(fields); i++ {

--- a/builder/parse_test.go
+++ b/builder/parse_test.go
@@ -18,10 +18,10 @@ func TestParseDockerBuildCmd(t *testing.T) {
 		{1, "-f Dockerfile -t {{.Run.ID}}:latest https://github.com/Azure/acr-builder.git", "Dockerfile", "https://github.com/Azure/acr-builder.git"},
 		{2, "https://github.com/Azure/acr-builder.git -f Dockerfile -t foo:bar", "Dockerfile", "https://github.com/Azure/acr-builder.git"},
 		{3, "https://github.com/Azure/acr-builder.git#master:blah -f Dockerfile -t foo:bar", "Dockerfile", "https://github.com/Azure/acr-builder.git#master:blah"},
-		{4, ".", "Dockerfile", "."},
+		{4, ".", "", "."},
 		{5, "--file src/Dockerfile . -t foo:bar", "src/Dockerfile", "."},
 		{6, "-f src/Dockerfile .", "src/Dockerfile", "."},
-		{7, "-t foo https://github.com/Azure/acr-builder.git#:HelloWorld", "Dockerfile", "https://github.com/Azure/acr-builder.git#:HelloWorld"},
+		{7, "-t foo https://github.com/Azure/acr-builder.git#:HelloWorld", "", "https://github.com/Azure/acr-builder.git#:HelloWorld"},
 	}
 
 	for _, test := range tests {

--- a/scan/dependencies_test.go
+++ b/scan/dependencies_test.go
@@ -129,3 +129,29 @@ func TestRemoveSurroundingQuotes(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateDockerfilePath(t *testing.T) {
+	tests := []struct {
+		context    string
+		workDir    string
+		dockerfile string
+		expected   string
+	}{
+		// Remote context
+		{"https://github.com/Azure/acr-builder.git", "", "", defaultDockerfile},
+		{"https://github.com/Azure/acr-builder.git", "build", "", "build/" + defaultDockerfile},
+		{"https://github.com/Azure/acr-builder.git#:foo/bar", "", "foo/bar/Dockerfile", "foo/bar/Dockerfile"},
+		{"https://github.com/Azure/acr-builder.git#:foo/bar", "build", "foo/bar/Dockerfile", "build/foo/bar/Dockerfile"},
+
+		// Local context
+		{".", ".", "", defaultDockerfile},
+		{"src/foo", "src/foo", "", "src/foo/" + defaultDockerfile},
+		{"src/foo", "src/foo", "bar/qux/Dockerfile", "bar/qux/Dockerfile"},
+	}
+
+	for _, test := range tests {
+		if actual := createDockerfilePath(test.context, test.workDir, test.dockerfile); actual != test.expected {
+			t.Errorf("expected %s but got %s", test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose of the PR:**

In the case of `docker build src/foo`, the Dockerfile will be looked at `src/foo`. Right now since we always default the Dockerfile to `Dockerfile`, we check at `.` when scanning for dependencies. This change makes it so that if we default the Dockerfile, we'll check for it relative to the specified context / working directory.

You can view an example of the current issue as this yaml: https://github.com/ehotinger/scratch/blob/master/acb-nested.yaml -- without this change the dependencies will be chosen from the Dockerfile in the root of the repository; with the change the dependencies are looked at in the proper subfolder.

**Fixes #434**