### PR TITLE
Fixes a minor typo on the class name for registry credential

### DIFF
--- a/graph/registry_credential.go
+++ b/graph/registry_credential.go
@@ -108,7 +108,7 @@ func CreateRegistryCredentialFromString(str string) (*RegistryCredential, error)
 	return retVal, nil
 }
 
-// Equals determines whether two RegistrCredentials are equal.
+// Equals determines whether two RegistryCredentials are equal.
 func (s *RegistryCredential) Equals(t *RegistryCredential) bool {
 	if s == nil && t == nil {
 		return true


### PR DESCRIPTION
**Purpose of the PR:**
- Fixes a minor typo on the class name for registry credential