### PR TITLE
Refactor akv to keyvault

### DIFF
--- a/cmd/acb/commands/getsecret/getsecret.go
+++ b/cmd/acb/commands/getsecret/getsecret.go
@@ -27,12 +27,12 @@ var Command = cli.Command{
 	Usage: "gets the secret value from a specified vault",
 	Subcommands: []cli.Command{
 		{
-			Name:  "akv",
-			Usage: "gets the secret value from azure keyvault. If it is an azure keyvault secret, it is assumed that the host has the MSI token service running at http://169.254.169.254/.",
+			Name:  "keyvault",
+			Usage: "gets the secret value from a key vault. If it is an Azure Key Vault (AKV) secret, it is assumed that the host has the MSI token service running at http://169.254.169.254/.",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "url",
-					Usage: "the azure keyvault secret URL",
+					Usage: "the secret URL",
 				},
 				cli.StringFlag{
 					Name:  "client-id",

--- a/docs/custom_registry_login.md
+++ b/docs/custom_registry_login.md
@@ -130,7 +130,7 @@ FROM hello-world
 ```
 vim mytask.yaml
 
-version: 1.0-preview-1
+version: v1.0.0
 steps:
   - build: -t registry1.azurecr.io/hello-world . -f hello-world.dockerfile
   - push: ["registry1.azurecr.io/hello-world"]

--- a/docs/getsecret_akv.md
+++ b/docs/getsecret_akv.md
@@ -2,11 +2,11 @@
 
 acr-builder has added support to get secrets from azure keyvault using managed service identity (https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview). It has a new command called **getsecret** that can fetch secret from different vault providers. Currently it supports secrets from Azure key vault. The below article describes how to use acb to retrieve a secret from Azure keyvault using Managed Identities. 
 
-We will use the command group "akv" of getsecret to retrieve secret from Azure keyvault.
+We will use the command group `keyvault` of getsecret to retrieve secrets from Azure keyvault.
 
 ```
 USAGE:
-   acb getsecret akv [command options] [arguments...]
+   acb getsecret keyvault [command options] [arguments...]
 
 OPTIONS:
    --url value                 the azure keyvault secret URL
@@ -90,7 +90,7 @@ az container create \
     --name acb-getsecret \
     --assign-identity $ID \
     --image <YourDockerHubUsername>/acb-getsecret \
-    --command-line "acb get-secret akv --url https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
+    --command-line "acb get-secret keyvault --url https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
 ```
 The above command will create the container instance and set up everything needed for Managed Identities.
 

--- a/docs/task-with-secrets.md
+++ b/docs/task-with-secrets.md
@@ -123,7 +123,7 @@ vim task-secrets.yaml
 version: 1.0-preview-1
 secrets:
   - id: mysecret
-    akv: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
+    keyvault: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
 steps:
   - cmd: bash echo mysecret value is {{.Secrets.mysecret}}
 
@@ -156,9 +156,9 @@ vim task-secrets.yaml
 version: 1.0-preview-1
 secrets:
   - id: mysecret
-    akv: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
+    keyvault: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
   - id: mysecret1
-    akv: {{.Values.akv1}}
+    keyvault: {{.Values.vault}}
     clientID: {{ .Values.id }}
 steps:
   - cmd: bash echo mysecret value is {{.Secrets.mysecret}}
@@ -166,7 +166,7 @@ steps:
 
 vim values.yaml
 
-akv1: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
+vault: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
 id: c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86
 
 ```

--- a/docs/task-with-secrets.md
+++ b/docs/task-with-secrets.md
@@ -120,7 +120,7 @@ docker tag <your-dockerhub-username>/acb-exec acb
 ```
 vim task-secrets.yaml
 
-version: 1.0-preview-1
+version: v1.0.0
 secrets:
   - id: mysecret
     keyvault: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353
@@ -153,7 +153,7 @@ mysecret value is ACB Secret
 ```
 vim task-secrets.yaml
 
-version: 1.0-preview-1
+version: v1.0.0
 secrets:
   - id: mysecret
     keyvault: https://myacbvault.vault.azure.net/secrets/SampleSecret/2c68e8cd93b941389ac2ad735ffc0353

--- a/docs/task.md
+++ b/docs/task.md
@@ -322,12 +322,12 @@ An object with the following properties:
 | Property | Type | Required | Default Value |
 |----------|------|----------|---------------|
 | `id` | `string` | Required | N/A |
-| [akv](#akv) | `string` | Optional | N/A |
+| [keyvault](#keyvault) | `string` | Optional | N/A |
 | [clientID](#clientid) | `string` | Optional | N/A |
 
-#### akv
+#### keyvault
 
-The Azure Key Vault (AKV) Secret URL.
+The key vault URL.
 
 * Optional
 * Type: `string`

--- a/graph/task.go
+++ b/graph/task.go
@@ -368,7 +368,7 @@ func ResolveCustomRegistryCredentials(ctx context.Context, credentials []*Regist
 		case Opaque:
 			usernameSecretObject.ResolvedValue = cred.Username
 		case VaultSecret:
-			usernameSecretObject.Akv = cred.Username
+			usernameSecretObject.KeyVault = cred.Username
 			usernameSecretObject.MsiClientID = cred.Identity
 			unresolvedCreds = append(unresolvedCreds, usernameSecretObject)
 		case "":
@@ -379,7 +379,7 @@ func ResolveCustomRegistryCredentials(ctx context.Context, credentials []*Regist
 		case Opaque:
 			passwordSecretObject.ResolvedValue = cred.Password
 		case VaultSecret:
-			passwordSecretObject.Akv = cred.Password
+			passwordSecretObject.KeyVault = cred.Password
 			passwordSecretObject.MsiClientID = cred.Identity
 			unresolvedCreds = append(unresolvedCreds, passwordSecretObject)
 		}

--- a/graph/task_test.go
+++ b/graph/task_test.go
@@ -182,18 +182,18 @@ func TestNewTaskFromString(t *testing.T) {
 		{`
 secrets:
   - id: mysecret
-    akv: https://myvault.vault.azure.net/secrets/mysecret
+    keyvault: https://myvault.vault.azure.net/secrets/mysecret
   - id: mysecret1
-    akv: https://myvault.vault.azure.net/secrets/mysecret1
+    keyvault: https://myvault.vault.azure.net/secrets/mysecret1
     clientID: c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86`,
 			[]*secretmgmt.Secret{
 				{
-					ID:  "mysecret",
-					Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+					ID:       "mysecret",
+					KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 				},
 				{
 					ID:          "mysecret1",
-					Akv:         "https://myvault.vault.azure.net/secrets/mysecret1",
+					KeyVault:    "https://myvault.vault.azure.net/secrets/mysecret1",
 					MsiClientID: "c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86",
 				},
 			},
@@ -219,9 +219,9 @@ secrets:`,
 		{`
 secrets:
   - id: mysecret1
-    akv: myakv
+    keyvault: secretvault1
   - id: mysecret1
-    akv: myakv2
+    keyvault: secretvault2
     clientID: c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86`,
 			[]*secretmgmt.Secret{},
 			true,

--- a/graph/testdata/sequential.yaml
+++ b/graph/testdata/sequential.yaml
@@ -1,9 +1,0 @@
-stepTimeout: 30
-
-secrets:
-  - akv: someAKV
-
-steps:
-  - timeout: 5
-    cmd: build -f Dockerfile -t foo:bar https://github.com/Azure/acr-builder.git
-  - push: [push1, push2, push3]

--- a/secretmgmt/secret.go
+++ b/secretmgmt/secret.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	errMissingSecretIDs      = errors.New("secret is missing an ID as well as auto-generated ID")
-	errMissingSecretProps    = errors.New("secret should contain either akv property for vault secret, or msi clientID/aadResourceId for msi authentication")
+	errMissingSecretProps    = errors.New("secret should contain either keyvault property for vault secret, or msi clientID/aadResourceId for msi authentication")
 	errSecretIDContainsSpace = errors.New("secret ID cannot contain spaces")
 	errInvalidUUID           = errors.New("msi client ID is not a valid guid")
 )
@@ -18,7 +18,7 @@ var (
 // Secret defines a wrapper to resolve vault secrets to values.
 type Secret struct {
 	ID          string `yaml:"id"`
-	Akv         string `yaml:"akv,omitempty"`
+	KeyVault    string `yaml:"keyvault,omitempty"`
 	MsiClientID string `yaml:"clientID,omitempty"`
 
 	// After the Secret is resolved, the value can be found here.
@@ -48,7 +48,7 @@ func (s *Secret) Validate() error {
 	if util.ContainsSpace(s.ID) {
 		return errSecretIDContainsSpace
 	}
-	if !s.IsAkvSecret() && !s.IsMsiSecret() {
+	if !s.IsKeyVaultSecret() && !s.IsMsiSecret() {
 		return errMissingSecretProps
 	}
 	if s.MsiClientID != "" && !util.IsValidUUID(s.MsiClientID) {
@@ -58,15 +58,15 @@ func (s *Secret) Validate() error {
 	return nil
 }
 
-// IsAkvSecret returns true if a Secret is of Azure Keyvault type, false otherwise.
-func (s *Secret) IsAkvSecret() bool {
+// IsKeyVaultSecret returns true if a Secret is a key vault, false otherwise.
+func (s *Secret) IsKeyVaultSecret() bool {
 	if s == nil {
 		return false
 	}
-	return s.Akv != ""
+	return s.KeyVault != ""
 }
 
-// IsMsiSecret returns true if a Secret is of MSI type, false otherwise.
+// IsMsiSecret returns true if a Secret is an MSI, false otherwise.
 func (s *Secret) IsMsiSecret() bool {
 	if s == nil {
 		return false
@@ -84,7 +84,7 @@ func (s *Secret) Equals(t *Secret) bool {
 	}
 
 	return s.ID == t.ID &&
-		s.Akv == t.Akv &&
+		s.KeyVault == t.KeyVault &&
 		s.MsiClientID == t.MsiClientID &&
 		s.AadResourceID == t.AadResourceID
 }

--- a/secretmgmt/secret_test.go
+++ b/secretmgmt/secret_test.go
@@ -35,8 +35,8 @@ func TestValidateSecret(t *testing.T) {
 		},
 		{
 			&Secret{
-				ID:  "a",
-				Akv: "b",
+				ID:       "a",
+				KeyVault: "b",
 			},
 			false,
 		},
@@ -44,7 +44,7 @@ func TestValidateSecret(t *testing.T) {
 			// Invalid UUID for MSI Client ID
 			&Secret{
 				ID:          "a",
-				Akv:         "b",
+				KeyVault:    "b",
 				MsiClientID: "test",
 			},
 			true,
@@ -52,7 +52,7 @@ func TestValidateSecret(t *testing.T) {
 		{
 			&Secret{
 				ID:          "a",
-				Akv:         "b",
+				KeyVault:    "b",
 				MsiClientID: "c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86",
 			},
 			false,
@@ -70,7 +70,7 @@ func TestValidateSecret(t *testing.T) {
 	}
 }
 
-func TestIsAkvSecret(t *testing.T) {
+func TestIsKeyVaultSecret(t *testing.T) {
 	tests := []struct {
 		secret   *Secret
 		expected bool
@@ -81,7 +81,7 @@ func TestIsAkvSecret(t *testing.T) {
 		},
 		{
 			&Secret{
-				Akv: "a",
+				KeyVault: "a",
 			},
 			true,
 		},
@@ -92,8 +92,8 @@ func TestIsAkvSecret(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if actual := test.secret.IsAkvSecret(); actual != test.expected {
-			t.Errorf("Expected %v for secret to be AKV type, but got %v", test.expected, actual)
+		if actual := test.secret.IsKeyVaultSecret(); actual != test.expected {
+			t.Errorf("Expected %v but got %v", test.expected, actual)
 		}
 	}
 }
@@ -159,12 +159,12 @@ func TestSecretEquals(t *testing.T) {
 		{
 			&Secret{
 				ID:          "a",
-				Akv:         "b",
+				KeyVault:    "b",
 				MsiClientID: "c",
 			},
 			&Secret{
 				ID:          "a",
-				Akv:         "b",
+				KeyVault:    "b",
 				MsiClientID: "c",
 			},
 			true,

--- a/secretmgmt/secrets.go
+++ b/secretmgmt/secrets.go
@@ -99,16 +99,16 @@ func resolveSecret(ctx context.Context, secret *Secret, errorChan chan error) {
 		return
 	}
 
-	if secret.IsAkvSecret() {
-		secretConfig, err := vaults.NewAKVSecretConfig(secret.Akv, secret.MsiClientID)
+	if secret.IsKeyVaultSecret() {
+		secretConfig, err := vaults.NewAKVSecretConfig(secret.KeyVault, secret.MsiClientID)
 		if err != nil {
-			errorChan <- errors.Wrap(err, "failed to create azure keyvault secret config")
+			errorChan <- errors.Wrap(err, "failed to create key vault secret config")
 			return
 		}
 
 		secretValue, err := secretConfig.GetValue(ctx)
 		if err != nil {
-			errorChan <- errors.Wrap(err, "failed to fetch azure key vault secret")
+			errorChan <- errors.Wrap(err, "failed to fetch key vault secret")
 			return
 		}
 
@@ -118,7 +118,7 @@ func resolveSecret(ctx context.Context, secret *Secret, errorChan chan error) {
 	} else if secret.IsMsiSecret() {
 		secretValue, err := tokenutil.GetRegistryRefreshToken(secret.ID, secret.AadResourceID, secret.MsiClientID)
 		if err != nil {
-			errorChan <- errors.Wrap(err, "failed to fetch Identity secret")
+			errorChan <- errors.Wrap(err, "failed to fetch identity secret")
 			return
 		}
 		secret.ResolvedValue = secretValue

--- a/secretmgmt/secrets_test.go
+++ b/secretmgmt/secrets_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-// MockResolveSecret will mock the azure keyvault resolve and return the concatenated Akv and client ID as the value. This is used for testing purposes only.
+// MockResolveSecret will mock the azure keyvault resolve and return the concatenated key vault and client ID as the value. This is used for testing purposes only.
 func MockResolveSecret(ctx context.Context, secret *Secret, errorChan chan error) {
 	if secret == nil {
 		errorChan <- errors.New("secret cannot be nil")
 		return
 	}
 
-	if secret.IsAkvSecret() {
-		secret.ResolvedValue = fmt.Sprintf("vault-%s-%s", secret.Akv, secret.MsiClientID)
+	if secret.IsKeyVaultSecret() {
+		secret.ResolvedValue = fmt.Sprintf("vault-%s-%s", secret.KeyVault, secret.MsiClientID)
 		secret.ResolvedChan <- true
 		return
 	} else if secret.IsMsiSecret() {
@@ -48,12 +48,12 @@ func TestResolveSecrets(t *testing.T) {
 		{
 			[]*Secret{
 				{
-					ID:  "mysecret",
-					Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+					ID:       "mysecret",
+					KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 				},
 				{
 					ID:          "mysecret1",
-					Akv:         "https://myvault.vault.azure.net/secrets/mysecret1",
+					KeyVault:    "https://myvault.vault.azure.net/secrets/mysecret1",
 					MsiClientID: "c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86",
 				},
 			},
@@ -71,44 +71,44 @@ func TestResolveSecrets(t *testing.T) {
 			// Add more than 5 secrets to test the batching logic
 			[]*Secret{
 				{
-					ID:  "1",
-					Akv: "k1",
+					ID:       "1",
+					KeyVault: "k1",
 				},
 				{
-					ID:  "2",
-					Akv: "k2",
+					ID:       "2",
+					KeyVault: "k2",
 				},
 				{
-					ID:  "3",
-					Akv: "k3",
+					ID:       "3",
+					KeyVault: "k3",
 				},
 				{
-					ID:  "4",
-					Akv: "k4",
+					ID:       "4",
+					KeyVault: "k4",
 				},
 				{
 					ID:            "5",
 					AadResourceID: "k5",
 				},
 				{
-					ID:  "6",
-					Akv: "k6",
+					ID:       "6",
+					KeyVault: "k6",
 				},
 				{
 					ID:            "7",
 					AadResourceID: "k7",
 				},
 				{
-					ID:  "8",
-					Akv: "k8",
+					ID:       "8",
+					KeyVault: "k8",
 				},
 				{
 					ID:            "9",
 					AadResourceID: "k9",
 				},
 				{
-					ID:  "10",
-					Akv: "k10",
+					ID:       "10",
+					KeyVault: "k10",
 				},
 			},
 			map[string]string{"1": "vault-k1-", "2": "vault-k2-", "3": "vault-k3-", "4": "vault-k4-", "5": "msi-k5-", "6": "vault-k6-", "7": "msi-k7-", "8": "vault-k8-", "9": "msi-k9-", "10": "vault-k10-"},
@@ -155,8 +155,8 @@ func TestResolveSecretsWithError(t *testing.T) {
 		{
 			[]*Secret{
 				{
-					ID:  "mysecret",
-					Akv: "some invalid akv URL",
+					ID:       "mysecret",
+					KeyVault: "some invalid URL",
 				},
 			},
 		},
@@ -180,32 +180,32 @@ func TestResolveSecretsWithTimeout(t *testing.T) {
 	ctx := context.Background()
 	secrets := []*Secret{
 		{
-			ID:  "mysecret1",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret1",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 		{
-			ID:  "mysecret2",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret2",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 		{
-			ID:  "mysecret3",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret3",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 		{
-			ID:  "mysecret4",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret4",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 		{
-			ID:  "mysecret5",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret5",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 		{
-			ID:  "mysecret6",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret6",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 		{
-			ID:  "mysecret7",
-			Akv: "https://myvault.vault.azure.net/secrets/mysecret",
+			ID:       "mysecret7",
+			KeyVault: "https://myvault.vault.azure.net/secrets/mysecret",
 		},
 	}
 

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-// MockResolveSecret will mock the azure keyvault resolve and return the concatenated Akv and client ID as the value. This is used for testing purposes only.
+// MockResolveSecret will mock the azure keyvault resolve and return the concatenated keyvault and client ID as the value. This is used for testing purposes only.
 func MockResolveSecret(ctx context.Context, secret *secretmgmt.Secret, errorChan chan error) {
 	if secret == nil {
 		errorChan <- errors.New("secret cannot be nil")
 		return
 	}
 
-	if secret.IsAkvSecret() {
-		secret.ResolvedValue = fmt.Sprintf("%s-%s", secret.Akv, secret.MsiClientID)
+	if secret.IsKeyVaultSecret() {
+		secret.ResolvedValue = fmt.Sprintf("%s-%s", secret.KeyVault, secret.MsiClientID)
 		secret.ResolvedChan <- true
 		return
 	}
@@ -165,9 +165,9 @@ func TestRenderAndResolveSecrets(t *testing.T) {
 		{`
 secrets:
   - id: mysecret
-    akv: https://myvault.vault.azure.net/secrets/mysecret
+    keyvault: https://myvault.vault.azure.net/secrets/mysecret
   - id: mysecret1
-    akv: https://myvault.vault.azure.net/secrets/mysecret1
+    keyvault: https://myvault.vault.azure.net/secrets/mysecret1
     clientID: c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86`,
 			Values{"mykey": "myvalue"},
 			Values{"mysecret": "https://myvault.vault.azure.net/secrets/mysecret-", "mysecret1": "https://myvault.vault.azure.net/secrets/mysecret1-c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86"},
@@ -176,9 +176,9 @@ secrets:
 		{`
 secrets:
   - id: mysecret
-    akv: {{.Values.myakv}}
+    keyvault: {{.Values.myakv}}
   - id: {{.Values.myid2}}
-    akv: {{.Values.myakv2}}
+    keyvault: {{.Values.myakv2}}
     clientID: {{.Values.myclientID}}`,
 			Values{"myid2": "mysecret1", "myakv": "https://myvault.vault.azure.net/secrets/mysecret", "myakv2": "https://myvault.vault.azure.net/secrets/mysecret1", "myclientID": "c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86"},
 			Values{"mysecret": "https://myvault.vault.azure.net/secrets/mysecret-", "mysecret1": "https://myvault.vault.azure.net/secrets/mysecret1-c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86"},
@@ -186,9 +186,9 @@ secrets:
 		{`
 secrets:
   - id: mysecret
-    akv: {{.Values.myakv}}
+    keyvault: {{.Values.myakv}}
   - id: {{.Run.ID}}_{{.Values.myid2}}
-    akv: {{.Values.myakv2}}
+    keyvault: {{.Values.myakv2}}
     clientID: {{.Values.myclientID}}`,
 			Values{"ID": "runId", "myid2": "mysecret1", "myakv": "https://myvault.vault.azure.net/secrets/mysecret", "myakv2": "https://myvault.vault.azure.net/secrets/mysecret1", "myclientID": "c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86"},
 			Values{"mysecret": "https://myvault.vault.azure.net/secrets/mysecret-", "runId_mysecret1": "https://myvault.vault.azure.net/secrets/mysecret1-c72b2df0-b9d8-4ac6-9363-7c1eb06c1c86"},
@@ -196,7 +196,7 @@ secrets:
 		{`
 secrets:
   - id: mysecret
-    akv: myakv`,
+    keyvault: myakv`,
 			Values{"mykey": "myvalue"},
 			Values{"mysecret": "myakv-"},
 		},


### PR DESCRIPTION
**Purpose of the PR:**

- Refactor the `akv` yaml property to `keyvault`, this also renames many of the `Akv*` structs to be `KeyVault` instead.