### PR TITLE
Fix Task level environment variables

### DIFF
--- a/builder/context_test.go
+++ b/builder/context_test.go
@@ -79,7 +79,7 @@ func TestGetImageDependencies(t *testing.T) {
 
 func TestGetBuildDockerRunArgs(t *testing.T) {
 	builder := &Builder{}
-	actualCmds := builder.getDockerRunArgs("volName", "stepWorkDir", &graph.Step{ID: "id", Build: "-f Dockerfile ."}, []string{"value1"}, "", "docker build -f Dockerfile .")
+	actualCmds := builder.getDockerRunArgs("volName", "stepWorkDir", &graph.Step{ID: "id", Build: "-f Dockerfile ."}, []string{"foo=bar"}, "", "docker build -f Dockerfile .")
 
 	var expectedCmds []string
 
@@ -87,13 +87,13 @@ func TestGetBuildDockerRunArgs(t *testing.T) {
 		expectedCmds = []string{
 			"powershell.exe",
 			"-Command",
-			"docker run --rm --env value1 --name id --volume volName:c:\\workspace --volume \\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine --volume home:c:\\acb\\home --env USERPROFILE=c:\\acb\\home --workdir c:\\workspace/stepWorkDir docker build -f Dockerfile .",
+			"docker run --rm --env foo=bar --name id --volume volName:c:\\workspace --volume \\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine --volume home:c:\\acb\\home --env USERPROFILE=c:\\acb\\home --workdir c:\\workspace/stepWorkDir docker build -f Dockerfile .",
 		}
 	} else {
 		expectedCmds = []string{
 			"/bin/sh",
 			"-c",
-			"docker run --rm --env value1 --name id --volume volName:/workspace --volume /var/run/docker.sock:/var/run/docker.sock --volume home:/acb/home --env HOME=/acb/home --workdir /workspace/stepWorkDir docker build -f Dockerfile .",
+			"docker run --rm --env foo=bar --name id --volume volName:/workspace --volume /var/run/docker.sock:/var/run/docker.sock --volume home:/acb/home --env HOME=/acb/home --workdir /workspace/stepWorkDir docker build -f Dockerfile .",
 		}
 	}
 
@@ -104,7 +104,7 @@ func TestGetBuildDockerRunArgs(t *testing.T) {
 
 func TestGetNonBuildDockerRunArgs(t *testing.T) {
 	builder := &Builder{}
-	actualCmds := builder.getDockerRunArgs("volName", "stepWorkDir", &graph.Step{ID: "id"}, []string{"value1"}, "", "hello-world")
+	actualCmds := builder.getDockerRunArgs("volName", "stepWorkDir", &graph.Step{ID: "id"}, []string{"foo=bar"}, "", "hello-world")
 
 	var expectedCmds []string
 
@@ -112,13 +112,13 @@ func TestGetNonBuildDockerRunArgs(t *testing.T) {
 		expectedCmds = []string{
 			"powershell.exe",
 			"-Command",
-			"docker run --rm --isolation hyperv --env value1 --name id --volume volName:c:\\workspace --volume \\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine --volume home:c:\\acb\\home --env USERPROFILE=c:\\acb\\home --workdir c:\\workspace/stepWorkDir hello-world",
+			"docker run --rm --isolation hyperv --env foo=bar --name id --volume volName:c:\\workspace --volume \\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine --volume home:c:\\acb\\home --env USERPROFILE=c:\\acb\\home --workdir c:\\workspace/stepWorkDir hello-world",
 		}
 	} else {
 		expectedCmds = []string{
 			"/bin/sh",
 			"-c",
-			"docker run --rm --env value1 --name id --volume volName:/workspace --volume /var/run/docker.sock:/var/run/docker.sock --volume home:/acb/home --env HOME=/acb/home --workdir /workspace/stepWorkDir hello-world",
+			"docker run --rm --env foo=bar --name id --volume volName:/workspace --volume /var/run/docker.sock:/var/run/docker.sock --volume home:/acb/home --env HOME=/acb/home --workdir /workspace/stepWorkDir hello-world",
 		}
 	}
 

--- a/graph/testdata/acb.yaml
+++ b/graph/testdata/acb.yaml
@@ -5,6 +5,9 @@
 stepTimeout: 600
 version: v1.0.0
 
+env:
+  - "foo=taskEnv"
+
 steps:
   - id: puller
     cmd: azure/images/docker pull ubuntu
@@ -56,6 +59,3 @@ steps:
     user: root
     network: "host"
     repeat: 2
-
-env:
-  - "foo=taskEnv"


### PR DESCRIPTION
**Purpose of the PR:**

- When default environment variables were introduced with MSI, these environment variables were overriding the entire Task's environment variables. I.e., if you had `env: [foo=bar]` at the Task level with no defaults, you'll end up with an empty slice. Now, we merge them together.

This also refactors some of the tests and functionality in that area as I was poking around.