### PR TITLE
replace deadline exceeded message with timed out

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -182,7 +182,7 @@ func (b *Builder) processVertex(ctx context.Context, task *graph.Task, parent *g
 }
 
 func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
-	log.Printf("Executing step ID: %s. Working directory: '%s', Network: '%s'\n", step.ID, step.WorkingDirectory, step.Network)
+	log.Printf("Executing step ID: %s. Timeout(sec): %d, Working directory: '%s', Network: '%s'\n", step.ID, step.Timeout, step.WorkingDirectory, step.Network)
 	if step.StartDelay > 0 {
 		log.Printf("Waiting %d seconds before executing step ID: %s\n", step.StartDelay, step.ID)
 		time.Sleep(time.Duration(step.StartDelay) * time.Second)

--- a/cmd/acb/main.go
+++ b/cmd/acb/main.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	buildCmd "github.com/Azure/acr-builder/cmd/acb/commands/build"
 	downloadCmd "github.com/Azure/acr-builder/cmd/acb/commands/download"
@@ -21,7 +23,7 @@ import (
 func main() {
 	app := New()
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, formatErrorMessage(err))
 		os.Exit(1)
 	}
 }
@@ -42,4 +44,9 @@ func New() *cli.App {
 		getsecretCmd.Command,
 	}
 	return app
+}
+
+func formatErrorMessage(err error) string {
+	// replace the original error message "context deadline exceeded" with "timed out"
+	return strings.ReplaceAll(err.Error(), context.DeadlineExceeded.Error(), "timed out")
 }

--- a/cmd/acb/main_test.go
+++ b/cmd/acb/main_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestFormatErrorMessage(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected string
+	}{
+		{
+			errors.New("context deadline exceeded"),
+			"timed out",
+		},
+		{
+			errors.Wrap(errors.New("context deadline exceeded"), "failed"),
+			"failed: timed out",
+		},
+	}
+
+	for _, test := range tests {
+		actual := formatErrorMessage(test.err)
+		if test.expected != actual {
+			t.Fatalf("Expected '%s' but got '%s'", test.expected, actual)
+		}
+	}
+}

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -6,6 +6,7 @@ package procmanager
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -33,7 +34,7 @@ func NewProcManager(dryRun bool) *ProcManager {
 }
 
 // RunRepeatWithRetries performs a Run multiple times with retries.
-// If an error occurs during the repetition, the last error will be returned.
+// If any error occurs during the repetition, all errors will be aggregated and returned.
 func (pm *ProcManager) RunRepeatWithRetries(
 	ctx context.Context,
 	args []string,
@@ -144,7 +145,14 @@ func (pm *ProcManager) Run(
 			}
 		}()
 
-		return ctx.Err()
+		err := ctx.Err()
+
+		// replace the original error message "context deadline exceeded" with "timed out"
+		if err == context.DeadlineExceeded {
+			return fmt.Errorf("timed out")
+		}
+
+		return err
 	}
 }
 

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -6,7 +6,6 @@ package procmanager
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -145,14 +144,7 @@ func (pm *ProcManager) Run(
 			}
 		}()
 
-		err := ctx.Err()
-
-		// replace the original error message "context deadline exceeded" with "timed out"
-		if err == context.DeadlineExceeded {
-			return fmt.Errorf("timed out")
-		}
-
-		return err
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
The change add timeout information to the step logs.

2019/05/17 22:01:20 Executing step ID: acb_step_0. **Timeout(sec): 10**, Working directory: '', Network: 'acb_default_network'
2019/05/17 22:01:20 Launching container with name: acb_step_0
2019/05/17 22:01:30 Container failed during run: acb_step_0. No retries remaining.
failed to run step ID: acb_step_0: **timed out**

**Fixes #382** 