### PR TITLE
Bump Go version to 1.12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - "1.12.1"
+  - "1.12.5"
   
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_CLI_BASE_IMAGE=docker:18.03.0-ce-git
 
-FROM golang:1.12-alpine AS gobuild-base
+FROM golang:1.12.5-alpine AS gobuild-base
 RUN apk add --no-cache \
 	git \
 	make

--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -66,7 +66,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 # 1. The go lang for 1803 tag is not available.
 # 2. The image pulls 2.11.1 version of MinGit which has an issue with git submodules command. https://github.com/git-for-windows/git/issues/1007#issuecomment-384281260
 
-ENV GOLANG_VERSION 1.12
+ENV GOLANG_VERSION 1.12.5
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \


### PR DESCRIPTION
**Purpose of the PR:**

- Bump Go version to 1.12.5