### PR TITLE
Update dockerignore to include yaml and Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,10 @@
 **/.dockerignore
-Dockerfile
-Windows.Dockerfile
 .git
 LICENSE
 *.md
 .github
 .travis.yml
 appveyor.yml
-*.yaml
 *.exe
 .vscode/
 /bin/


### PR DESCRIPTION
**Purpose of the PR**

- Update dockerignore to include yaml and Dockerfiles. Otherwise when you run `az acr run ...` the dockerignore will kick in causing you not to be able to use the `acb.yaml` or the Dockerfiles.