### PR TITLE
support --target in dependency scan

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -254,7 +254,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 	var args []string
 
 	if step.IsBuildStep() {
-		dockerfile, dockerContext := parseDockerBuildCmd(step.Build)
+		dockerfile, target, dockerContext := parseDockerBuildCmd(step.Build)
 		volName := b.workspaceDir
 
 		// Print out a warning message if a remote context doesn't appear to be valid, i.e. doesn't end with .git.
@@ -264,7 +264,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 		timeout := time.Duration(scrapeTimeoutInSec) * time.Second
 		scrapeCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
-		deps, err := b.scrapeDependencies(scrapeCtx, volName, step.WorkingDirectory, step.ID, dockerfile, dockerContext, step.Tags, step.BuildArgs)
+		deps, err := b.scrapeDependencies(scrapeCtx, volName, step.WorkingDirectory, step.ID, dockerfile, dockerContext, step.Tags, step.BuildArgs, target)
 		if err != nil {
 			return errors.Wrap(err, "failed to scan dependencies")
 		}

--- a/builder/context.go
+++ b/builder/context.go
@@ -148,7 +148,8 @@ func (b *Builder) scrapeDependencies(
 	dockerfile string,
 	sourceContext string,
 	tags []string,
-	buildArgs []string) ([]*image.Dependencies, error) {
+	buildArgs []string,
+	target string) ([]*image.Dependencies, error) {
 	containerName := fmt.Sprintf("acb_dep_scanner_%s", uuid.New())
 
 	args := getScanArgs(
@@ -160,6 +161,7 @@ func (b *Builder) scrapeDependencies(
 		outputDir,
 		tags,
 		buildArgs,
+		target,
 		sourceContext)
 
 	if b.debug {
@@ -186,6 +188,7 @@ func getScanArgs(
 	outputDir string,
 	tags []string,
 	buildArgs []string,
+	target string,
 	sourceContext string) []string {
 	args := []string{
 		"docker",
@@ -211,6 +214,10 @@ func getScanArgs(
 
 	for _, buildArg := range buildArgs {
 		args = append(args, "--build-arg", buildArg)
+	}
+
+	if len(target) > 0 {
+		args = append(args, "--target", target)
 	}
 
 	// Positional context must appear last

--- a/builder/context_test.go
+++ b/builder/context_test.go
@@ -137,6 +137,7 @@ func TestGetScanArgs(t *testing.T) {
 		outputDir             string
 		tags                  []string
 		buildArgs             []string
+		target                string
 		context               string
 		expected              string
 	}{
@@ -149,6 +150,7 @@ func TestGetScanArgs(t *testing.T) {
 			"OutputDirectory",
 			[]string{"tag1", "tag2"},
 			[]string{"arg1=a", "arg2=b"},
+			"build",
 			"someContext",
 			"docker run --rm " +
 				"--name containerName " +
@@ -157,7 +159,7 @@ func TestGetScanArgs(t *testing.T) {
 				"--volume " + homeVol + ":" + homeWorkDir + " " +
 				"--env " + homeEnv + " " +
 				"acb scan -f Dockerfile --destination OutputDirectory " +
-				"-t tag1 -t tag2 --build-arg arg1=a --build-arg arg2=b someContext",
+				"-t tag1 -t tag2 --build-arg arg1=a --build-arg arg2=b --target build someContext",
 		},
 	}
 
@@ -172,6 +174,7 @@ func TestGetScanArgs(t *testing.T) {
 				test.outputDir,
 				test.tags,
 				test.buildArgs,
+				test.target,
 				test.context),
 			" ")
 		if test.expected != actual {

--- a/builder/parse.go
+++ b/builder/parse.go
@@ -17,18 +17,21 @@ const (
 )
 
 // parseDockerBuildCmd parses a docker build command and extracts the
-// context and Dockerfile from it.
-func parseDockerBuildCmd(cmd string) (dockerfile string, context string) {
+// context, target and Dockerfile from it.
+func parseDockerBuildCmd(cmd string) (dockerfile string, target string, context string) {
 	fields := strings.Fields(cmd)
 	prev := ""
 	dockerfile = ""
 	context = "."
+	target = ""
 
 	for i := 0; i < len(fields); i++ {
 		v := fields[i]
 
 		if prev == "-f" || prev == "--file" {
 			dockerfile = v
+		} else if prev == "--target" {
+			target = v
 		} else if !strings.HasPrefix(prev, "-") && !strings.HasPrefix(v, "-") {
 			context = v
 		}
@@ -36,7 +39,7 @@ func parseDockerBuildCmd(cmd string) (dockerfile string, context string) {
 		prev = v
 	}
 
-	return dockerfile, context
+	return dockerfile, target, context
 }
 
 // replacePositionalContext parses the specified command for its positional context

--- a/builder/parse_test.go
+++ b/builder/parse_test.go
@@ -13,21 +13,26 @@ func TestParseDockerBuildCmd(t *testing.T) {
 		id         int
 		build      string
 		dockerfile string
+		target     string
 		context    string
 	}{
-		{1, "-f Dockerfile -t {{.Run.ID}}:latest https://github.com/Azure/acr-builder.git", "Dockerfile", "https://github.com/Azure/acr-builder.git"},
-		{2, "https://github.com/Azure/acr-builder.git -f Dockerfile -t foo:bar", "Dockerfile", "https://github.com/Azure/acr-builder.git"},
-		{3, "https://github.com/Azure/acr-builder.git#master:blah -f Dockerfile -t foo:bar", "Dockerfile", "https://github.com/Azure/acr-builder.git#master:blah"},
-		{4, ".", "", "."},
-		{5, "--file src/Dockerfile . -t foo:bar", "src/Dockerfile", "."},
-		{6, "-f src/Dockerfile .", "src/Dockerfile", "."},
-		{7, "-t foo https://github.com/Azure/acr-builder.git#:HelloWorld", "", "https://github.com/Azure/acr-builder.git#:HelloWorld"},
+		{1, "-f Dockerfile -t {{.Run.ID}}:latest https://github.com/Azure/acr-builder.git", "Dockerfile", "", "https://github.com/Azure/acr-builder.git"},
+		{2, "https://github.com/Azure/acr-builder.git -f Dockerfile -t foo:bar", "Dockerfile", "", "https://github.com/Azure/acr-builder.git"},
+		{3, "https://github.com/Azure/acr-builder.git#master:blah -f Dockerfile -t foo:bar", "Dockerfile", "", "https://github.com/Azure/acr-builder.git#master:blah"},
+		{4, ".", "", "", "."},
+		{5, "--file src/Dockerfile . -t foo:bar", "src/Dockerfile", "", "."},
+		{6, "-f src/Dockerfile .", "src/Dockerfile", "", "."},
+		{7, "-t foo https://github.com/Azure/acr-builder.git#:HelloWorld", "", "", "https://github.com/Azure/acr-builder.git#:HelloWorld"},
+		{8, "-t foo --target build https://github.com/Azure/acr-builder.git#:HelloWorld", "", "build", "https://github.com/Azure/acr-builder.git#:HelloWorld"},
 	}
 
 	for _, test := range tests {
-		dockerfile, context := parseDockerBuildCmd(test.build)
+		dockerfile, target, context := parseDockerBuildCmd(test.build)
 		if test.dockerfile != dockerfile {
 			t.Errorf("Test %d failed. Expected %s as the dockerfile, got %s", test.id, test.dockerfile, dockerfile)
+		}
+		if test.target != target {
+			t.Errorf("Test %d failed. Expected %s as the target, got %s", test.id, test.target, target)
 		}
 		if test.context != context {
 			t.Errorf("Test %d failed. Expected %s as the context, got %s", test.id, test.context, context)

--- a/cmd/acb/commands/download/download.go
+++ b/cmd/acb/commands/download/download.go
@@ -57,7 +57,7 @@ var Command = cli.Command{
 		defer cancel()
 
 		pm := procmanager.NewProcManager(dryRun)
-		scanner, err := scan.NewScanner(pm, downloadCtx, "", destination, nil, nil)
+		scanner, err := scan.NewScanner(pm, downloadCtx, "", destination, nil, nil, "")
 		if err != nil {
 			return err
 		}

--- a/cmd/acb/commands/scan/scan.go
+++ b/cmd/acb/commands/scan/scan.go
@@ -48,6 +48,10 @@ var Command = cli.Command{
 			Name:  "build-arg",
 			Usage: "build arguments",
 		},
+		cli.StringFlag{
+			Name:  "target",
+			Usage: "build target",
+		},
 		cli.Int64Flag{
 			Name:  "timeout",
 			Usage: "maximum execution time in seconds",
@@ -63,6 +67,7 @@ var Command = cli.Command{
 			destination = context.String("destination")
 			tags        = context.StringSlice("tag")
 			buildArgs   = context.StringSlice("build-arg")
+			target      = context.String("target")
 			timeout     = time.Duration(context.Int64("timeout")) * time.Second
 		)
 
@@ -80,7 +85,7 @@ var Command = cli.Command{
 		}
 
 		pm := procmanager.NewProcManager(dryRun)
-		scanner, err := scan.NewScanner(pm, downloadCtx, dockerfile, destination, buildArgs, tags)
+		scanner, err := scan.NewScanner(pm, downloadCtx, dockerfile, destination, buildArgs, tags, target)
 		if err != nil {
 			return err
 		}

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -20,10 +20,11 @@ type Scanner struct {
 	destinationFolder string
 	buildArgs         []string
 	tags              []string
+	target            string
 }
 
 // NewScanner creates a new Scanner.
-func NewScanner(pm *procmanager.ProcManager, sourceContext string, dockerfile string, destination string, buildArgs []string, tags []string) (*Scanner, error) {
+func NewScanner(pm *procmanager.ProcManager, sourceContext string, dockerfile string, destination string, buildArgs []string, tags []string, target string) (*Scanner, error) {
 	// NOTE (bindu): vendor/github.com/docker/docker/pkg/idtools/idtools_unix.go#mkdirAs (L51-60) looks for "/" to determine the root folder.
 	// But if it is a relative path, the code will enter dead-loop. Ensure passing in the absolute path to workaround the bug.
 	var err error
@@ -40,6 +41,7 @@ func NewScanner(pm *procmanager.ProcManager, sourceContext string, dockerfile st
 		destinationFolder: destination,
 		buildArgs:         buildArgs,
 		tags:              tags,
+		target:            target,
 	}, nil
 }
 
@@ -50,7 +52,7 @@ func (s *Scanner) Scan(ctx context.Context) (deps []*image.Dependencies, err err
 		return deps, errors.Wrap(err, "failed to download source code")
 	}
 
-	deps, err = s.ScanForDependencies(s.context, workingDir, s.dockerfile, s.buildArgs, s.tags)
+	deps, err = s.ScanForDependencies(s.context, workingDir, s.dockerfile, s.buildArgs, s.tags, s.target)
 	if err != nil {
 		return deps, err
 	}


### PR DESCRIPTION
Fixes #495 
if --target is specified in build step, depdendency scan will parse the base images to the target stage.

