### PR TITLE
fix alias bug + refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,5 +32,3 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+go 1.13

--- a/graph/dag_test.go
+++ b/graph/dag_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestDagCreation_ValidFile(t *testing.T) {
-	task, err := UnmarshalTaskFromFile(gocontext.Background(), "testdata/acb.yaml", nil, "", true)
+	task, err := UnmarshalTaskFromFile(gocontext.Background(), "testdata/acb.yaml", &TaskOptions{
+		DoPreprocessing: true,		
+	})
 	if err != nil {
 		t.Fatalf("Failed to create task from file. Err: %v", err)
 	}
@@ -178,7 +180,10 @@ func TestDagCreation_ValidFile(t *testing.T) {
 }
 
 func TestBuildxInBuildTask_ValidFile(t *testing.T) {
-	task, err := UnmarshalTaskFromFile(gocontext.Background(), "testdata/buildx.yaml", nil, "samsTask", true)
+	task, err := UnmarshalTaskFromFile(gocontext.Background(), "testdata/buildx.yaml", &TaskOptions{
+		TaskName: "samsTask",
+		DoPreprocessing: true,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create task from file. Err: %v", err)
 	}
@@ -217,7 +222,9 @@ func TestBuildxInBuildTask_ValidFile(t *testing.T) {
 }
 
 func TestBuildxQuickRun_ValidFile(t *testing.T) {
-	task, err := UnmarshalTaskFromFile(gocontext.Background(), "testdata/buildx.yaml", nil, "", true)
+	task, err := UnmarshalTaskFromFile(gocontext.Background(), "testdata/buildx.yaml", &TaskOptions{
+		DoPreprocessing: true,
+	})
 	if err != nil {
 		t.Fatalf("Failed to create task from file. Err: %v", err)
 	}

--- a/graph/preprocessor.go
+++ b/graph/preprocessor.go
@@ -220,8 +220,8 @@ func preprocessString(alias *Alias, str string) (string, bool, error) {
 	return out.String(), changed, nil
 }
 
-// preprocessBytes handles byte encoded data that can be parsed through pre processing
-func preprocessBytes(data []byte) ([]byte, Alias, bool, error) {
+// PreprocessBytes handles byte encoded data that can be parsed through pre processing
+func PreprocessBytes(data []byte) ([]byte, *Alias, bool, error) {
 	type Wrapper struct {
 		Alias Alias `yaml:"alias,omitempty"`
 	}
@@ -230,7 +230,7 @@ func preprocessBytes(data []byte) ([]byte, Alias, bool, error) {
 	aliasData, remainingData := basicAliasSeparation(data)
 
 	if errUnmarshal := yaml.Unmarshal(aliasData, wrap); errUnmarshal != nil {
-		return data, Alias{}, false, errUnmarshal
+		return data, &Alias{}, false, errUnmarshal
 	}
 
 	alias := &wrap.Alias
@@ -243,12 +243,12 @@ func preprocessBytes(data []byte) ([]byte, Alias, bool, error) {
 	str := string(remainingData)
 	parsedStr, changed, err := preprocessString(alias, str)
 
-	return []byte(parsedStr), *alias, changed, err
+	return []byte(parsedStr), alias, changed, err
 }
 
-// processSteps Will resolve image names in steps that are aliased without using directive.
+// ExpandCommandAliases will resolve image names in cmd steps that are aliased without using directive.
 // Invoked after resolving all directive using aliases
-func processSteps(alias *Alias, task *Task) {
+func ExpandCommandAliases(alias *Alias, task *Task) {
 	for i, step := range task.Steps {
 		parts := strings.Split(strings.TrimSpace(step.Cmd), " ")
 		if val, ok := alias.AliasMap[parts[0]]; ok {

--- a/graph/preprocessor_test.go
+++ b/graph/preprocessor_test.go
@@ -421,7 +421,7 @@ func TestPreProcessBytes(t *testing.T) {
 
 	for _, test := range tests {
 		input := yamlMap[test.nameAndTaskIdentifier]
-		data, _, _, err := PreprocessBytes(input)
+		data, _, _, err := PreprocessBytes(input, nil)
 		if err != nil && test.shouldError {
 			continue
 		}

--- a/graph/preprocessor_test.go
+++ b/graph/preprocessor_test.go
@@ -421,7 +421,7 @@ func TestPreProcessBytes(t *testing.T) {
 
 	for _, test := range tests {
 		input := yamlMap[test.nameAndTaskIdentifier]
-		data, _, _, err := preprocessBytes(input)
+		data, _, _, err := PreprocessBytes(input)
 		if err != nil && test.shouldError {
 			continue
 		}
@@ -559,7 +559,7 @@ func TestPreProcessSteps(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		processSteps(&test.alias, &test.current)
+		ExpandCommandAliases(&test.alias, &test.current)
 
 		if test.current.Steps[0].Cmd != test.expected.Cmd {
 			t.Fatalf("Test " + test.nameAndTaskIdentifier + " expected: " + test.expected.Cmd + " but resolved to " + test.current.Steps[0].Cmd)

--- a/graph/registry_credential.go
+++ b/graph/registry_credential.go
@@ -37,6 +37,22 @@ type RegistryCredential struct {
 	AadResourceID string `json:"aadResourceId,omitempty"`
 }
 
+// CreateRegistryCredentialFromList creates a list of RegistryCredential
+// objects from list of serialized credentials.
+func CreateRegistryCredentialFromList(creds []string) ([]*RegistryCredential, error) {
+	var credentials []*RegistryCredential
+	for _, credString := range creds {
+		var cred *RegistryCredential
+		cred, err := CreateRegistryCredentialFromString(credString)
+		if err != nil {
+			return nil, err
+		}
+		credentials = append(credentials, cred)
+	}
+
+	return credentials, nil
+}
+
 // CreateRegistryCredentialFromString creates a RegistryCredential object from a serialized string.
 func CreateRegistryCredentialFromString(str string) (*RegistryCredential, error) {
 	var cred RegistryCredential

--- a/graph/task.go
+++ b/graph/task.go
@@ -147,7 +147,7 @@ func NewTaskFromString(data string, doPreprocessing bool) (*Task, error) {
 func NewTaskFromBytes(data []byte, doPreprocessing bool) (*Task, error) {
 	t := &Task{}
 	if doPreprocessing {
-		post, alias, changed, aliasErr := preprocessBytes(data)
+		post, alias, changed, aliasErr := PreprocessBytes(data)
 
 		if aliasErr != nil {
 			return t, aliasErr
@@ -161,7 +161,7 @@ func NewTaskFromBytes(data []byte, doPreprocessing bool) (*Task, error) {
 			}
 			return t, err
 		}
-		processSteps(&alias, t)
+		ExpandCommandAliases(alias, t)
 
 	} else {
 		if err := yaml.Unmarshal(data, t); err != nil {

--- a/graph/task_test.go
+++ b/graph/task_test.go
@@ -265,7 +265,7 @@ steps:
 	}
 
 	for _, test := range tests {
-		task, err := NewTaskFromString(test.template, true)
+		task, err := NewTaskFromString(test.template, &TaskOptions{DoPreprocessing: true})
 		if test.shouldError && err == nil {
 			t.Fatalf("Expected task: %v to error but it didn't", test.template)
 		}
@@ -381,13 +381,14 @@ env: ["a=b", "c=d"]
 		actual, err := UnmarshalTaskFromString(
 			context.Background(),
 			test.data,
-			test.defaultWorkDir,
-			test.network,
-			test.envs,
-			test.creds,
-			test.taskName,
-			true,
-		)
+			&TaskOptions{
+				DefaultWorkingDir: test.defaultWorkDir,
+				Network:           test.network,
+				Envs:              test.envs,
+				Credentials:       test.creds,
+				TaskName:          test.taskName,
+				DoPreprocessing:   true,
+			})
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -79,9 +79,10 @@ type BaseRenderOptions struct {
 	TaskName string
 }
 
-// OverrideValuesWithBuildInfo overrides the specified config's values and provides a default set of values.
-func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions) (Values, error) {
-	base := map[string]interface{}{
+// GetTaskRenderObject returns an Object based on Task primitives.
+// You can use this object to pass into Go template engine.
+func GetTaskRenderObject(opts *BaseRenderOptions) Values {
+	return map[string]interface{}{
 		"Build": map[string]interface{}{
 			"ID": opts.ID,
 		},
@@ -102,6 +103,11 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 			"TaskName":     opts.TaskName,
 		},
 	}
+}
+
+// OverrideValuesWithBuildInfo overrides the specified config's values and provides a default set of values.
+func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions) (Values, error) {
+	base := GetTaskRenderObject(opts)
 
 	vals, err := OverrideValues(c1, c2)
 	if err != nil {
@@ -177,8 +183,13 @@ func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRende
 }
 
 // renderAndResolveSecrets parses the secrets in the template, resolves them using vault providers and returns the resolved secret values.
-func renderAndResolveSecrets(ctx context.Context, template *Template, templateEngine *Engine, resolveSecretFunc secretmgmt.ResolveSecretFunc, opts *BaseRenderOptions, sourceValues Values) (Values, error) {
-
+func renderAndResolveSecrets(
+	ctx context.Context,
+	template *Template,
+	templateEngine *Engine,
+	resolveSecretFunc secretmgmt.ResolveSecretFunc,
+	opts *BaseRenderOptions,
+	sourceValues Values) (Values, error) {
 	result := Values{}
 	// Cheap optimization to skip the secrets merging if it doesn't contain "secrets" string in it. Note that the task can
 	// have the string secrets but may not essentially the secrets section.
@@ -198,7 +209,7 @@ func renderAndResolveSecrets(ctx context.Context, template *Template, templateEn
 	}
 
 	// Unmarshall the template to Task and get all secrets defined in the template.
-	task, err := graph.NewTaskFromString(rendered, false)
+	task, err := graph.NewTaskFromString(rendered, &graph.TaskOptions{DoPreprocessing: false})
 	if err != nil {
 		return result, errors.Wrap(err, "failed to parse template to create task")
 	}

--- a/templating/engine.go
+++ b/templating/engine.go
@@ -52,7 +52,11 @@ func (e *Engine) Render(t *Template, values Values) (string, error) {
 }
 
 func (e *Engine) render(rt renderableTemplate) (rendered string, err error) {
-	// If a template panics, recover the engine.
+	return e.RenderGoTemplate(rt.name, rt.template, rt.values)
+}
+
+// RenderGoTemplate renders a go template given template and data.
+func (e *Engine) RenderGoTemplate(name string, input string, data interface{}) (rendered string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("Template rendering recovered. Value: %v\n", r)
@@ -68,14 +72,14 @@ func (e *Engine) render(rt renderableTemplate) (rendered string, err error) {
 		t.Option("missingkey=zero")
 	}
 
-	t = t.New(rt.name).Funcs(e.FuncMap)
-	if _, err := t.Parse(rt.template); err != nil {
-		return "", fmt.Errorf("failed to parse template: %s. Err: %v", rt.name, err)
+	t = t.New(name).Funcs(e.FuncMap)
+	if _, err := t.Parse(input); err != nil {
+		return "", fmt.Errorf("failed to parse template: %s. Err: %v", name, err)
 	}
 
 	var buf bytes.Buffer
-	if err := t.ExecuteTemplate(&buf, rt.name, rt.values); err != nil {
-		return "", fmt.Errorf("failed to execute template: %s. Err: %v", rt.name, err)
+	if err := t.ExecuteTemplate(&buf, name, data); err != nil {
+		return "", fmt.Errorf("failed to execute template: %s. Err: %v", name, err)
 	}
 
 	// NB: handle `missingkey=zero` by removing the string.


### PR DESCRIPTION
**Purpose of the PR**

Re-ordered steps for exec.

Instead of: 
1. Preprocess task
2. Unmarshal task
3. Expand command aliases
4. Marshal task
5. Render gotemplates
6. Unmarshal Task for run

we simplify to this:
1. Preprocess task
2. Render gotemplates
3. Unmarshal task for run
4. Expand command aliases

Also as a part of #501 

Fixes #511