### PR TITLE
load images from cache if using buildx

### DIFF
--- a/cmd/acb/commands/exec/exec.go
+++ b/cmd/acb/commands/exec/exec.go
@@ -249,6 +249,7 @@ var Command = cli.Command{
 			Envs:              defaultEnvs,
 			Credentials:       credentials,
 			TaskName:          taskName,
+			Registry:          registry,
 		})
 		if errUnmarshal != nil {
 			return errors.Wrap(errUnmarshal, "failed to unmarshal task before running")

--- a/graph/step_test.go
+++ b/graph/step_test.go
@@ -386,6 +386,7 @@ func TestGetCmdForBuildCache(t *testing.T) {
 	tests := []struct {
 		s        *Step
 		taskName string
+		registry string
 		result   string
 		ok       bool
 	}{
@@ -396,16 +397,18 @@ func TestGetCmdForBuildCache(t *testing.T) {
 			},
 			"",
 			"",
+			"",
 			false,
 		},
 		{
 			&Step{
-				Tags:  []string{"a"},
+				Tags:  []string{"abcd"},
 				Cache: "enabled",
 			},
 			"",
-			"",
-			false,
+			"sam.azurecr.io",
+			"sam.azurecr.io/abcd",
+			true,
 		},
 		{
 			&Step{
@@ -414,6 +417,7 @@ func TestGetCmdForBuildCache(t *testing.T) {
 				Cache: "enabled",
 			},
 			"fooTask",
+			"",
 			"test.com/repo:cache_fooTask_step0",
 			true,
 		},
@@ -424,6 +428,7 @@ func TestGetCmdForBuildCache(t *testing.T) {
 				Cache: "enAbled",
 			},
 			noTaskNamePlaceholder,
+			"",
 			"test.com/repo:cache_" + noTaskNamePlaceholder + "_step_acb0",
 			true,
 		},
@@ -435,6 +440,7 @@ func TestGetCmdForBuildCache(t *testing.T) {
 			},
 			"task_myrandomlylongIDlaskcnlkascnlkanclkansclknaslkcnalkscnlaknsclkalknaslkncalscnlakscnlkascnlkascnlksn",
 			"",
+			"",
 			false,
 		},
 		{
@@ -444,6 +450,7 @@ func TestGetCmdForBuildCache(t *testing.T) {
 				Cache: "enabled",
 			},
 			"foo",
+			"",
 			"test:5000/repo:cache_foo_a_b_c",
 			true,
 		},
@@ -454,6 +461,7 @@ func TestGetCmdForBuildCache(t *testing.T) {
 				Cache: "enabled",
 			},
 			"myTask",
+			"",
 			"foo/foo_bar.com:cache_myTask_step_acb0",
 			true,
 		},
@@ -464,13 +472,47 @@ func TestGetCmdForBuildCache(t *testing.T) {
 				Cache: "enabled",
 			},
 			noTaskNamePlaceholder,
+			"",
 			"sub-dom1.foo.com/bar/baz/quux:cache_" + noTaskNamePlaceholder + "_1",
+			true,
+		},
+		{
+			&Step{
+				ID:    "1",
+				Tags:  []string{"sub-dom1.foo.com/bar/baz/quux"},
+				Cache: "enabled",
+			},
+			noTaskNamePlaceholder,
+			"",
+			"sub-dom1.foo.com/bar/baz/quux:cache_" + noTaskNamePlaceholder + "_1",
+			true,
+		},
+		{
+			&Step{
+				ID:    "1",
+				Tags:  []string{"a", "b", "c", "d"},
+				Cache: "enabled",
+			},
+			noTaskNamePlaceholder,
+			"sam.azurecr.io",
+			"sam.azurecr.io/a:cache_" + noTaskNamePlaceholder + "_1",
+			true,
+		},
+		{
+			&Step{
+				ID:    "1",
+				Tags:  []string{"a", "sam.azurecr.io/foo", "c", "d"},
+				Cache: "enabled",
+			},
+			noTaskNamePlaceholder,
+			"sam.azurecr.io",
+			"sam.azurecr.io/foo:cache_" + noTaskNamePlaceholder + "_1",
 			true,
 		},
 	}
 
 	for _, test := range tests {
-		actual, err := test.s.GetCmdWithCacheFlags(test.taskName)
+		actual, err := test.s.GetCmdWithCacheFlags(test.taskName, "sam.azurecr.io")
 
 		if test.ok {
 			if err != nil {

--- a/graph/task.go
+++ b/graph/task.go
@@ -58,6 +58,7 @@ type Task struct {
 	WorkingDirectory         string               `yaml:"workingDirectory,omitempty"`
 	Version                  string               `yaml:"version,omitempty"`
 	RegistryName             string
+	Registry                 string
 	TaskName                 string // Used to form the build cache image tag.
 	Credentials              []*RegistryCredential
 	RegistryLoginCredentials RegistryLoginCredentials
@@ -82,6 +83,9 @@ type TaskOptions struct {
 
 	// TaskName is the name of the Task
 	TaskName string
+
+	// Registry is the login server for Task
+	Registry string
 
 	// DoPreprocessing is a property to decide whether we use Alias
 	DoPreprocessing bool
@@ -123,6 +127,8 @@ func (t *Task) AddTaskDefaults(ctx context.Context, opts *TaskOptions) error {
 	} else {
 		t.TaskName = noTaskNamePlaceholder
 	}
+
+	t.Registry = opts.Registry
 
 	// External network parsed in from CLI will be set as default network, it will be used for any step if no network provide for them
 	// The external network is append at the end of the list of networks, later we will do reverse iteration to get this network
@@ -314,7 +320,7 @@ func (t *Task) initialize(ctx context.Context) error {
 
 			if s.UseBuildCacheForBuildStep() {
 				if runtime.GOOS == util.LinuxOS {
-					if buildStepWithBuildCache, err := s.GetCmdWithCacheFlags(t.TaskName); err != nil {
+					if buildStepWithBuildCache, err := s.GetCmdWithCacheFlags(t.TaskName, t.Registry); err != nil {
 						log.Printf("error creating build cache command %v\n", err)
 					} else {
 						// update the Build cmd with buildx cache flags


### PR DESCRIPTION
Signed-off-by: Sam <samashah@microsoft.com>

**Purpose of the PR**
Adds the functionality to load images into docker store built with using buildx (cache: enabled flag).

If build contains no tags, we just append a buildx `--load` flag.

If build contains at least one tag, but no domain - we grab the Registry login server and create a cache image you can use in future for your builds.

If build contains at least one tag, and has a login server (fully qualified image name), we use that domain for image cache.


Fixes #