### PR TITLE
Refactor load and render in templating

### DIFF
--- a/cmd/acb/commands/build/build.go
+++ b/cmd/acb/commands/build/build.go
@@ -314,7 +314,7 @@ func createBuildTask(
 	// Create the template
 	template := templating.NewTemplate("build", []byte(runCmd))
 
-	rendered, err := templating.LoadAndRenderSteps(ctx, template, renderOpts)
+	rendered, err := templating.LoadAndRenderBuildSteps(ctx, template, renderOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -127,7 +127,7 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 // and base render options.
 func LoadAndRenderBuildSteps(ctx context.Context, template *Template, opts *BaseRenderOptions) (string, error) {
 	// load steps and override values
-	mergedVals, err := LoadSteps(template, opts)
+	mergedVals, err := loadSteps(template, opts)
 	if err != nil {
 		return "", fmt.Errorf("error while loading build steps: %v", err)
 	}
@@ -150,7 +150,7 @@ func LoadAndRenderBuildSteps(ctx context.Context, template *Template, opts *Base
 // and base render options.
 func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRenderOptions) (string, error) {
 	// load steps and override values
-	mergedVals, err := LoadSteps(template, opts)
+	mergedVals, err := loadSteps(template, opts)
 	if err != nil {
 		return "", fmt.Errorf("error while loading exec steps: %v", err)
 	}
@@ -180,8 +180,8 @@ func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRende
 	return rendered, nil
 }
 
-// LoadSteps loads a template file and overrides values with build info
-func LoadSteps(template *Template, opts *BaseRenderOptions) (Values, error) {
+// loadSteps loads a template file and overrides values with build info
+func loadSteps(template *Template, opts *BaseRenderOptions) (Values, error) {
 	// return empty values list for an empty template.
 	if len(template.GetData()) == 0 {
 		return nil, nil

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -224,7 +224,6 @@ func renderAndResolveSecrets(
 	opts *BaseRenderOptions,
 	sourceValues Values) (Values, error) {
 	result := Values{}
-
 	// Cheap optimization to skip the secrets merging if the yaml definition file doesn't contain "secrets" string in it. Note that the task can
 	// have the string secrets but may not essentially the secrets section.
 	if !strings.Contains(string(template.Data), "secrets") {

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -154,6 +154,10 @@ func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRende
 	if err != nil {
 		return "", fmt.Errorf("error while loading exec steps: %v", err)
 	}
+	// return empty rendered string for an empty template.
+	if mergedVals == nil {
+		return "", nil
+	}
 
 	engine := NewEngine()
 	// we will pass nil for the secret resolve override so as to use the default resolve function.
@@ -178,7 +182,7 @@ func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRende
 
 // LoadSteps loads a template file and overrides values with build info
 func LoadSteps(template *Template, opts *BaseRenderOptions) (Values, error) {
-	// return empty rendered string for an empty template.
+	// return empty values list for an empty template.
 	if len(template.GetData()) == 0 {
 		return nil, nil
 	}
@@ -224,7 +228,7 @@ func renderAndResolveSecrets(
 	opts *BaseRenderOptions,
 	sourceValues Values) (Values, error) {
 	result := Values{}
-	// Cheap optimization to skip the secrets merging if the yaml definition file doesn't contain "secrets" string in it. Note that the task can
+	// Cheap optimization to skip the secrets merging if the task definition file doesn't contain "secrets" string in it. Note that the task can
 	// have the string secrets but may not essentially the secrets section.
 	if !strings.Contains(string(template.Data), "secrets") {
 		return result, nil

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -149,7 +149,7 @@ func LoadAndRenderBuildSteps(ctx context.Context, template *Template, opts *Base
 // LoadAndRenderSteps loads a template file for exec and renders it according to an optional values file, --set values,
 // and base render options.
 func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRenderOptions) (string, error) {
-    // load steps and override values
+	// load steps and override values
 	mergedVals, err := LoadSteps(template, opts)
 	if err != nil {
 		return "", fmt.Errorf("error while loading exec steps: %v", err)

--- a/templating/base_render_options.go
+++ b/templating/base_render_options.go
@@ -123,41 +123,36 @@ func OverrideValuesWithBuildInfo(c1 *Config, c2 *Config, opts *BaseRenderOptions
 	return base, nil
 }
 
-// LoadAndRenderSteps loads a template file and renders it according to an optional values file, --set values,
+// LoadAndRenderBuildSteps loads a template file for build and renders it according to an optional values file, --set values,
+// and base render options.
+func LoadAndRenderBuildSteps(ctx context.Context, template *Template, opts *BaseRenderOptions) (string, error) {
+	// load steps and override values
+	mergedVals, err := LoadSteps(template, opts)
+	if err != nil {
+		return "", fmt.Errorf("error while loading build steps: %v", err)
+	}
+
+	engine := NewEngine()
+
+	rendered, err := engine.Render(template, mergedVals)
+	if err != nil {
+		return "", fmt.Errorf("error while rendering templates: %v", err)
+	}
+
+	if rendered == "" {
+		return "", errors.New("rendered template was empty")
+	}
+
+	return rendered, nil
+}
+
+// LoadAndRenderSteps loads a template file for exec and renders it according to an optional values file, --set values,
 // and base render options.
 func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRenderOptions) (string, error) {
-	// return empty rendered string for an empty template.
-	if len(template.GetData()) == 0 {
-		return "", nil
-	}
-
-	var err error
-
-	config := &Config{}
-	if opts.ValuesFile != "" {
-		if config, err = LoadConfig(opts.ValuesFile); err != nil {
-			return "", err
-		}
-	} else if opts.Base64EncodedValuesFile != "" {
-		if config, err = DecodeConfig(opts.Base64EncodedValuesFile); err != nil {
-			return "", err
-		}
-	}
-
-	setConfig := &Config{}
-	if len(opts.TemplateValues) > 0 {
-		var rawVals string
-		rawVals, err = parseValues(opts.TemplateValues)
-		if err != nil {
-			return "", err
-		}
-
-		setConfig = &Config{RawValue: rawVals, Values: map[string]*Value{}}
-	}
-
-	mergedVals, err := OverrideValuesWithBuildInfo(config, setConfig, opts)
+    // load steps and override values
+	mergedVals, err := LoadSteps(template, opts)
 	if err != nil {
-		return "", fmt.Errorf("failed to override values: %v", err)
+		return "", fmt.Errorf("error while loading exec steps: %v", err)
 	}
 
 	engine := NewEngine()
@@ -181,6 +176,45 @@ func LoadAndRenderSteps(ctx context.Context, template *Template, opts *BaseRende
 	return rendered, nil
 }
 
+// LoadSteps loads a template file and overrides values with build info
+func LoadSteps(template *Template, opts *BaseRenderOptions) (Values, error) {
+	// return empty rendered string for an empty template.
+	if len(template.GetData()) == 0 {
+		return nil, nil
+	}
+
+	var err error
+
+	config := &Config{}
+	if opts.ValuesFile != "" {
+		if config, err = LoadConfig(opts.ValuesFile); err != nil {
+			return nil, err
+		}
+	} else if opts.Base64EncodedValuesFile != "" {
+		if config, err = DecodeConfig(opts.Base64EncodedValuesFile); err != nil {
+			return nil, err
+		}
+	}
+
+	setConfig := &Config{}
+	if len(opts.TemplateValues) > 0 {
+		var rawVals string
+		rawVals, err = parseValues(opts.TemplateValues)
+		if err != nil {
+			return nil, err
+		}
+
+		setConfig = &Config{RawValue: rawVals, Values: map[string]*Value{}}
+	}
+
+	mergedVals, err := OverrideValuesWithBuildInfo(config, setConfig, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to override values: %v", err)
+	}
+
+	return mergedVals, nil
+}
+
 // renderAndResolveSecrets parses the secrets in the template, resolves them using vault providers and returns the resolved secret values.
 func renderAndResolveSecrets(
 	ctx context.Context,
@@ -190,7 +224,8 @@ func renderAndResolveSecrets(
 	opts *BaseRenderOptions,
 	sourceValues Values) (Values, error) {
 	result := Values{}
-	// Cheap optimization to skip the secrets merging if it doesn't contain "secrets" string in it. Note that the task can
+
+	// Cheap optimization to skip the secrets merging if the yaml definition file doesn't contain "secrets" string in it. Note that the task can
 	// have the string secrets but may not essentially the secrets section.
 	if !strings.Contains(string(template.Data), "secrets") {
 		return result, nil

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -143,7 +143,7 @@ func TestLoadAndRenderBuildSteps(t *testing.T) {
 	}
 	tests := []struct {
 		buildFile string
-		expected string
+		expected  string
 	}{
 		{
 			"testdata/caching/Dockerfile-test",

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -142,29 +142,25 @@ func TestLoadAndRenderBuildSteps(t *testing.T) {
 		ValuesFile: "",
 	}
 	tests := []struct {
-		buildFile string
-		expected  string
+		runCmd string
 	}{
 		{
-			"testdata/caching/Dockerfile-test",
-			`FROM node:9-alpine
-
-ENV NODE_VERSION 9.11.1a`,
+			"--pull --label a=b --no-cache -f Dockerfile --bug-arg c=d -t mytag:latest --platform linux/amd64 /workspace",
 		},
 	}
 
 	for _, test := range tests {
-		var template *Template
-		template, err := LoadTemplate(test.buildFile)
-		if err != nil {
-			t.Fatalf("Unexpected err: %v", err)
-		}
+
+		// Create the template
+		template := NewTemplate("build", []byte(test.runCmd))
 
 		actual, err := LoadAndRenderBuildSteps(context.Background(), template, opts)
 		if err != nil {
 			t.Fatalf("Unexpected err: %v", err)
 		}
-		expected := adjustCRInExpectedStringOnWindows(test.expected)
+
+		expected := adjustCRInExpectedStringOnWindows(test.runCmd)
+		// Build does not need to render. Just check that the run commands were loaded.
 		if actual != expected {
 			t.Errorf("Expected \n%s\n but got \n%s\n", expected, actual)
 		}

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -137,6 +137,39 @@ func TestLoadAndRenderSteps(t *testing.T) {
 	}
 }
 
+func TestLoadAndRenderBuildSteps(t *testing.T) {
+	opts := &BaseRenderOptions{
+	}
+	tests := []struct {
+		buildFile string
+		expected string
+	}{
+		{
+			"testdata/caching/Dockerfile-test",
+			`FROM node:9-alpine
+
+ENV NODE_VERSION 9.11.1a`,
+		},
+	}
+
+	for _, test := range tests {
+		var template *Template
+		template, err := LoadTemplate(test.buildFile)
+		if err != nil {
+			t.Fatalf("Unexpected err: %v", err)
+		}
+
+		actual, err := LoadAndRenderBuildSteps(context.Background(), template, opts)
+		if err != nil {
+			t.Fatalf("Unexpected err: %v", err)
+		}
+		expected := adjustCRInExpectedStringOnWindows(test.expected)
+		if actual != expected {
+			t.Errorf("Expected \n%s\n but got \n%s\n", expected, actual)
+		}
+	}
+}
+
 func TestShellQuote(t *testing.T) {
 	tests := []struct {
 		original string

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -140,12 +140,15 @@ func TestLoadAndRenderSteps(t *testing.T) {
 func TestLoadAndRenderBuildSteps(t *testing.T) {
 	opts := &BaseRenderOptions{
 		ValuesFile: "",
+		ID:         "testid",
 	}
 	tests := []struct {
-		runCmd string
+		runCmd               string
+		expectedRenderedStep string
 	}{
 		{
-			"--pull --label a=b --no-cache -f Dockerfile --bug-arg c=d -t mytag:latest --platform linux/amd64 /workspace",
+			"--pull --label a=b --no-cache -f Dockerfile --bug-arg c=d -t secretstore:{{.Run.ID}} --platform linux/amd64 /workspace",
+			"--pull --label a=b --no-cache -f Dockerfile --bug-arg c=d -t secretstore:testid --platform linux/amd64 /workspace",
 		},
 	}
 
@@ -159,10 +162,9 @@ func TestLoadAndRenderBuildSteps(t *testing.T) {
 			t.Fatalf("Unexpected err: %v", err)
 		}
 
-		expected := adjustCRInExpectedStringOnWindows(test.runCmd)
 		// Build does not need to render. Just check that the run commands were loaded.
-		if actual != expected {
-			t.Errorf("Expected \n%s\n but got \n%s\n", expected, actual)
+		if actual != test.expectedRenderedStep {
+			t.Errorf("Expected \n%s\n but got \n%s\n", test.expectedRenderedStep, actual)
 		}
 	}
 }

--- a/templating/base_render_options_test.go
+++ b/templating/base_render_options_test.go
@@ -139,6 +139,7 @@ func TestLoadAndRenderSteps(t *testing.T) {
 
 func TestLoadAndRenderBuildSteps(t *testing.T) {
 	opts := &BaseRenderOptions{
+		ValuesFile: "",
 	}
 	tests := []struct {
 		buildFile string

--- a/templating/testdata/caching/Dockerfile-test
+++ b/templating/testdata/caching/Dockerfile-test
@@ -1,3 +1,0 @@
-FROM node:9-alpine
-
-ENV NODE_VERSION 9.11.1a

--- a/templating/testdata/caching/Dockerfile-test
+++ b/templating/testdata/caching/Dockerfile-test
@@ -1,0 +1,3 @@
+FROM node:9-alpine
+
+ENV NODE_VERSION 9.11.1a


### PR DESCRIPTION
**Purpose of the PR**

- fixes an bug where `LoadAndRenderSteps` tries to render secrets from build parameters if they contain the string "secrets" (ie. the tag name), a functionality used for exec. This breaks during unmarshal as the build content is usually not valid yaml.
- refactor the load and render methods so that build does not try to resolve secrets. We will expand the load logic of exec in the future so we decided to separate the paths now.

Fixes #540 