### PR TITLE
handle quotes for docker build step args

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ If your testing Task file contains pulling/pushing stuff off a private repositor
 If you don't need that, you can skip the following step.
 
 ### Create a home volume for Docker to find your registry credentials.
+
+From the `cmd/acb/` folder run
+
 ```sh
 sudo docker volume create home
 sudo docker volume inspect home
@@ -170,3 +173,5 @@ sudo ln -s $(HOME)/.docker /var/lib/docker/volumes/home/_data
     ]
 }
 ```
+
+Press F5.

--- a/builder/parse.go
+++ b/builder/parse.go
@@ -6,6 +6,8 @@ package builder
 import (
 	"regexp"
 	"strings"
+
+	"github.com/Azure/acr-builder/util"
 )
 
 var httpPrefix = regexp.MustCompile("^https?://")
@@ -28,12 +30,13 @@ func parseDockerBuildCmd(cmd string) (dockerfile string, target string, context 
 	for i := 0; i < len(fields); i++ {
 		v := fields[i]
 
+		// trim quotes on all docker build command args
 		if prev == "-f" || prev == "--file" {
-			dockerfile = v
+			dockerfile = util.TrimQuotes(v)
 		} else if prev == "--target" {
-			target = v
+			target = util.TrimQuotes(v)
 		} else if !strings.HasPrefix(prev, "-") && !strings.HasPrefix(v, "-") {
-			context = v
+			context = util.TrimQuotes(v)
 		}
 
 		prev = v

--- a/util/trim.go
+++ b/util/trim.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package util
+
+import "strings"
+
+// TrimQuote returns a slice of the string s, with all leading
+// and trailing double or single quotes removed, as defined by Unicode.
+func TrimQuotes(s string) string {
+	if strings.HasPrefix(s, "'") {
+		return strings.Trim(s, "'")
+	}
+	return strings.Trim(s, "\"")
+}

--- a/util/trim_test.go
+++ b/util/trim_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package util
+
+import "testing"
+
+func TestTrimQuotes(t *testing.T) {
+	tests := []struct {
+		s        string
+		expected string
+	}{
+		{`Dockerfile`, `Dockerfile`},
+		{`"Dockerfile"`, `Dockerfile`},
+		{`'Dockerfile'`, `Dockerfile`},
+		{`'Dockerfile"`, `Dockerfile"`},
+		{`'Dockerfile '`, `Dockerfile `},
+		{`'   Dockerfile '`, `   Dockerfile `},
+	}
+
+	for _, test := range tests {
+		if actual := TrimQuotes(test.s); actual != test.expected {
+			t.Errorf("Expected %v but got %v", test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose of the PR**

- Allow the build step parser to handle quotes around arguments.

Fixes #537 