### PR TITLE
use bash as the default config image

### DIFF
--- a/builder/constants_linux.go
+++ b/builder/constants_linux.go
@@ -10,7 +10,7 @@ const (
 	// containerWorkspaceDir is the default working directory for a container.
 	containerWorkspaceDir = "/workspace"
 
-	configImageName = "ubuntu"
+	configImageName = "bash"
 )
 
 var homeEnv = "HOME=" + homeWorkDir


### PR DESCRIPTION
**Purpose of the PR**

Use bash as the config image for linux. Its size is 20% of ubuntu. 