### PR TITLE
add retryonerror for windows build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_CLI_BASE_IMAGE=docker:19.03.6-git
 
-FROM golang:1.13.8-alpine AS gobuild-base
+FROM golang:1.14.2-alpine AS gobuild-base
 RUN apk add --no-cache \
 	git \
 	make

--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -62,11 +62,8 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 
 # install go lang
-# ideally we should be able to use FROM golang:windowsservercore-1803. This is not done due to two reasons
-# 1. The go lang for 1803 tag is not available.
-# 2. The image pulls 2.11.1 version of MinGit which has an issue with git submodules command. https://github.com/git-for-windows/git/issues/1007#issuecomment-384281260
 
-ENV GOLANG_VERSION 1.13.8
+ENV GOLANG_VERSION 1.14.2
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -100,6 +100,7 @@ func (b *Builder) RunTask(ctx context.Context, task *graph.Task) error {
 			"",
 			"",
 			"",
+			"",
 			buildkitdContainerName,
 			buildxImg+" create --use",
 		)
@@ -119,6 +120,7 @@ func (b *Builder) RunTask(ctx context.Context, task *graph.Task) error {
 			os.Stderr,
 			"",
 			buildkitdContainerInitRetries,
+			nil,
 			buildkitdContainerInitRetryDelay,
 			buildkitdContainerName,
 			buildkitdContainerInitRepeat,
@@ -323,6 +325,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step) error {
 		os.Stderr,
 		"",
 		step.Retries,
+		step.RetryOnErrors,
 		step.RetryDelayInSeconds,
 		step.ID,
 		step.Repeat,

--- a/builder/context.go
+++ b/builder/context.go
@@ -38,6 +38,7 @@ func (b *Builder) getDockerRunArgs(
 	user string,
 	network string,
 	isolation string,
+	cpus string,
 	entrypoint string,
 	containerName string,
 	cmd string) []string {
@@ -75,6 +76,9 @@ func (b *Builder) getDockerRunArgs(
 	}
 	if isolation != "" {
 		sb.WriteString(" --isolation " + isolation)
+	}
+	if cpus != "" {
+		sb.WriteString(" --cpus " + cpus)
 	}
 	if entrypoint != "" {
 		sb.WriteString(" --entrypoint " + entrypoint)
@@ -117,6 +121,11 @@ func (b *Builder) getDockerRunArgsForStep(
 		step.Isolation = "hyperv"
 	}
 
+	if runtime.GOOS == util.WindowsOS && step.IsBuildStep() {
+		// Limit build command container cpu to 1
+		step.CPUS = "1"
+	}
+
 	return b.getDockerRunArgs(
 		volName,
 		stepWorkDir,
@@ -130,6 +139,7 @@ func (b *Builder) getDockerRunArgsForStep(
 		step.User,
 		step.Network,
 		step.Isolation,
+		step.CPUS,
 		entrypoint,
 		step.ID,
 		cmd,

--- a/builder/context_test.go
+++ b/builder/context_test.go
@@ -88,7 +88,7 @@ func TestGetBuildDockerRunArgs(t *testing.T) {
 		expectedCmds = []string{
 			"powershell.exe",
 			"-Command",
-			"docker run --rm --name id --volume volName:c:\\workspace --volume \\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine --volume home:c:\\acb\\home --env USERPROFILE=c:\\acb\\home --env foo=bar --env HOME=qux --workdir c:\\workspace/stepWorkDir docker build -f Dockerfile .",
+			"docker run --rm --cpus 1 --name id --volume volName:c:\\workspace --volume \\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine --volume home:c:\\acb\\home --env USERPROFILE=c:\\acb\\home --env foo=bar --env HOME=qux --workdir c:\\workspace/stepWorkDir docker build -f Dockerfile .",
 		}
 	} else {
 		expectedCmds = []string{

--- a/cmd/acb/commands/build/build.go
+++ b/cmd/acb/commands/build/build.go
@@ -336,6 +336,13 @@ func createBuildTask(
 		Tags:    tags,
 	}
 
+	// For windows build, retry on "(0xc0370109)" error
+	if runtime.GOOS == util.WindowsOS {
+		buildStep.Retries = 3
+		buildStep.RetryOnErrors = []string{"(0xc0370109)"}
+		buildStep.RetryDelayInSeconds = 5
+	}
+
 	steps := []*graph.Step{buildStep}
 
 	if push {

--- a/graph/step.go
+++ b/graph/step.go
@@ -57,6 +57,7 @@ type Step struct {
 	User                string   `yaml:"user"`
 	Network             string   `yaml:"network"`
 	Isolation           string   `yaml:"isolation"`
+	CPUS                string   `yaml:"cpus"`
 	Cache               string   `yaml:"cache"`
 	Push                []string `yaml:"push"`
 	Envs                []string `yaml:"env"`
@@ -69,7 +70,8 @@ type Step struct {
 	StartDelay          int      `yaml:"startDelay"`
 	RetryDelayInSeconds int      `yaml:"retryDelay"`
 	// Retries specifies how many times a Step will be retried if it fails after its initial execution.
-	Retries int `yaml:"retries"`
+	Retries       int      `yaml:"retries"`
+	RetryOnErrors []string `yaml:"retryOnErrors"`
 	// Repeat specifies how many times a Step will be repeated after its initial execution.
 	Repeat                          int  `yaml:"repeat"`
 	Keep                            bool `yaml:"keep"`
@@ -218,7 +220,7 @@ func (s *Step) IsPushStep() bool {
 // UpdateBuildStepWithDefaults updates a build step with hyperv isolation on Windows.
 func (s *Step) UpdateBuildStepWithDefaults() {
 	if s.IsBuildStep() && runtime.GOOS == util.WindowsOS && !strings.Contains(s.Build, "--isolation") {
-		s.Build = fmt.Sprintf("--isolation hyperv %s", s.Build)
+		s.Build = fmt.Sprintf("--isolation hyperv %s -m 2GB", s.Build)
 	}
 }
 

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -106,6 +106,7 @@ func (pm *ProcManager) RunWithRetries(
 			}
 
 			log.Printf("Container failed during run: %s. No retries remaining.\n", containerName)
+			break
 		}
 	}
 	return err

--- a/pkg/procmanager/procmanager_test.go
+++ b/pkg/procmanager/procmanager_test.go
@@ -4,6 +4,7 @@
 package procmanager
 
 import (
+	"bytes"
 	"context"
 	"testing"
 )
@@ -19,5 +20,45 @@ func TestRun_NilArgs(t *testing.T) {
 	pm := NewProcManager(false)
 	if err := pm.Run(context.Background(), nil, nil, nil, nil, ""); err != nil {
 		t.Fatalf("Unexpected err: %v", err)
+	}
+}
+
+func TestContainsAnyError(t *testing.T) {
+	tests := []struct {
+		errors    []string
+		stdOutBuf *bytes.Buffer
+		stdErrBuf *bytes.Buffer
+		expected  bool
+	}{
+		{
+			[]string{"error1", "error2"},
+			new(bytes.Buffer),
+			new(bytes.Buffer),
+			false,
+		},
+		{
+			[]string{"error1", "error2"},
+			bytes.NewBufferString("abc error1"),
+			bytes.NewBufferString(""),
+			true,
+		},
+		{
+			[]string{"error1", "error2"},
+			bytes.NewBufferString("abc"),
+			bytes.NewBufferString("error2"),
+			true,
+		},
+		{
+			[]string{"error1", "error2"},
+			bytes.NewBufferString("abc"),
+			bytes.NewBufferString("def"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		if actual := containsAnyError(test.errors, test.stdErrBuf, test.stdOutBuf); actual != test.expected {
+			t.Errorf("expected %t but got %t", test.expected, actual)
+		}
 	}
 }


### PR DESCRIPTION
**Purpose of the PR**

The change enables an auto-retry on windows build error timeout error (0xc0370109). To support retry on errors (stdout or stderr), the change introduces a retryOnErrors property on steps. So it can be explicitly specified on step.

```
steps:
 - cmd: myimage 
   retryOnErrorrs: ["error1", "error2"]
   retries: 3 
```

The change also increases the windows build memory from default 1G to 2G and limits windows `docker` command container to 1 cpu.
