### PR TITLE
Read 2048 magic bytes to accommodate extended pax

### DIFF
--- a/scan/context.go
+++ b/scan/context.go
@@ -100,7 +100,8 @@ func (s *Scanner) getContextFromReader(r io.Reader) (err error) {
 	buf := bufio.NewReader(r)
 	var magic []byte
 
-	magic, err = buf.Peek(archiveHeaderSize)
+	// note: (sam) read 2048 magic bytes to accomodate Extended Pax headers.
+	magic, err = buf.Peek(archiveHeaderSize * 4)
 	if err != nil && err != io.EOF {
 		return errors.Wrap(err, "failed to peek context header")
 	}


### PR DESCRIPTION
**Purpose of the PR**

- Read 2048 magic bytes to accommodate PAX tarfiles
https://github.com/docker/cli/pull/1770/files


Fixes #