### PR TITLE
fix mis-prefix custom registry image tag in build

### DIFF
--- a/graph/task.go
+++ b/graph/task.go
@@ -332,7 +332,7 @@ func (t *Task) initialize(ctx context.Context) error {
 				}
 			}
 		} else if s.IsPushStep() {
-			s.Push = getNormalizedDockerImageNames(s.Push, t.RegistryName)
+			s.Push = getNormalizedDockerImageNames(s.Push)
 		}
 	}
 	var err error
@@ -352,7 +352,7 @@ func (t *Task) UsingRegistryCreds() bool {
 
 // getNormalizedDockerImageNames normalizes the list of docker images
 // and removes any duplicates.
-func getNormalizedDockerImageNames(dockerImages []string, registry string) []string {
+func getNormalizedDockerImageNames(dockerImages []string) []string {
 	if len(dockerImages) == 0 {
 		return dockerImages
 	}
@@ -361,7 +361,6 @@ func getNormalizedDockerImageNames(dockerImages []string, registry string) []str
 	normalizedDockerImages := []string{}
 	for _, dockerImage := range dockerImages {
 		d := scan.NormalizeImageTag(dockerImage)
-		d = util.PrefixRegistryToImageName(registry, d)
 		if dict[d] {
 			continue
 		}

--- a/util/prefixes.go
+++ b/util/prefixes.go
@@ -8,27 +8,37 @@ import (
 	"strings"
 )
 
+// PrefixTags prefixes tags in the specified command and returns the new command.
+func PrefixTags(cmd string, registry string, allKnownRegistries []string) (joinedTags string, tags []string) {
+	fields := strings.Fields(cmd)
+	for i := 1; i < len(fields); i++ {
+		if fields[i-1] == "-t" || fields[i-1] == "--tag" {
+			fields[i] = PrefixRegistryToImageName(registry, fields[i], allKnownRegistries)
+			tags = append(tags, fields[i])
+		}
+	}
+	return strings.Join(fields, " "), tags
+}
+
 // PrefixRegistryToImageName prefixes the specified registry to the image.
-func PrefixRegistryToImageName(registry string, img string) string {
+func PrefixRegistryToImageName(registry string, img string, allKnownRegistries []string) string {
 	if registry == "" {
 		return img
 	}
 
-	if !strings.HasPrefix(img, registry) && !strings.HasPrefix(img, "library/") {
+	if !hasKnownRegistryPrefix(img, allKnownRegistries) && !strings.HasPrefix(img, "library/") {
 		return fmt.Sprintf("%s/%s", registry, img)
 	}
 
 	return img
 }
 
-// PrefixTags prefixes tags in the specified command and returns the new command.
-func PrefixTags(cmd string, registry string) (joinedTags string, tags []string) {
-	fields := strings.Fields(cmd)
-	for i := 1; i < len(fields); i++ {
-		if fields[i-1] == "-t" || fields[i-1] == "--tag" {
-			fields[i] = PrefixRegistryToImageName(registry, fields[i])
-			tags = append(tags, fields[i])
+func hasKnownRegistryPrefix(img string, allKnownRegistries []string) bool {
+	for _, registry := range allKnownRegistries {
+		if registry != "" && strings.HasPrefix(img, registry) {
+			return true
 		}
 	}
-	return strings.Join(fields, " "), tags
+
+	return false
 }

--- a/util/prefixes_test.go
+++ b/util/prefixes_test.go
@@ -9,19 +9,22 @@ import (
 
 func TestPrefixRegistryToImageName(t *testing.T) {
 	tests := []struct {
-		registry string
-		img      string
-		expected string
+		registry           string
+		img                string
+		allKnownRegistries []string
+		expected           string
 	}{
-		{"", "someimg", "someimg"},
-		{"", "foo:latest", "foo:latest"},
-		{"foo", "someimg", "foo/someimg"},
-		{"foo", "someimg:bar", "foo/someimg:bar"},
-		{"foo", "library/someimg:bar", "library/someimg:bar"},
+		{"", "someimg", []string{""}, "someimg"},
+		{"", "foo:latest", []string{""}, "foo:latest"},
+		{"foo", "someimg", []string{"foo"}, "foo/someimg"},
+		{"foo", "someimg:bar", []string{"foo"}, "foo/someimg:bar"},
+		{"foo", "library/someimg:bar", []string{"foo"}, "library/someimg:bar"},
+		{"foo", "library/someimg:bar", []string{"foo"}, "library/someimg:bar"},
+		{"foo", "bar/someimage:latest", []string{"foo", "bar"}, "bar/someimage:latest"},
 	}
 
 	for _, test := range tests {
-		actual := PrefixRegistryToImageName(test.registry, test.img)
+		actual := PrefixRegistryToImageName(test.registry, test.img, test.allKnownRegistries)
 		if actual != test.expected {
 			t.Errorf("expected %s, got %s", test.expected, actual)
 		}
@@ -30,39 +33,57 @@ func TestPrefixRegistryToImageName(t *testing.T) {
 
 func TestPrefixTags(t *testing.T) {
 	tests := []struct {
-		registry     string
-		cmd          string
-		expected     string
-		expectedTags []string
+		registry           string
+		allKnownRegistries []string
+		cmd                string
+		expected           string
+		expectedTags       []string
 	}{
 		{
 			"foo.azurecr.io",
+			[]string{"foo.azurecr.io"},
 			"build -f Dockerfile . -t test:latest --tag bar",
 			"build -f Dockerfile . -t foo.azurecr.io/test:latest --tag foo.azurecr.io/bar",
 			[]string{"foo.azurecr.io/test:latest", "foo.azurecr.io/bar"},
 		},
 		{
 			"",
+			[]string{""},
 			"build -t bar/foo:latest . --tag bar",
 			"build -t bar/foo:latest . --tag bar",
 			[]string{"bar/foo:latest", "bar"},
 		},
-		{"foo.azurecr.io", "build -f Dockerfile . -t foo.azurecr.io/test:latest", "build -f Dockerfile . -t foo.azurecr.io/test:latest", []string{"foo.azurecr.io/test:latest"}},
+		{
+			"foo.azurecr.io",
+			[]string{"foo.azurecr.io"},
+			"build -f Dockerfile . -t foo.azurecr.io/test:latest",
+			"build -f Dockerfile . -t foo.azurecr.io/test:latest",
+			[]string{"foo.azurecr.io/test:latest"},
+		},
 		{
 			"sample.azurecr.io",
+			[]string{"sample.azurecr.io"},
 			"build -f src/Dockerfile https://github.com/Azure/acr-builder.git -t testing/sub/repo:l",
 			"build -f src/Dockerfile https://github.com/Azure/acr-builder.git -t sample.azurecr.io/testing/sub/repo:l",
 			[]string{"sample.azurecr.io/testing/sub/repo:l"},
 		},
 		{
 			"foo.azurecr.io",
+			[]string{"foo.azurecr.io"},
 			"build -f Dockerfile -t library/test:latest",
 			"build -f Dockerfile -t library/test:latest",
 			[]string{"library/test:latest"},
 		},
+		{
+			"foo.azurecr.io",
+			[]string{"foo.azurecr.io", "bar.azurecr.io"},
+			"build -f Dockerfile -t bar.azurecr.io/test:latest",
+			"build -f Dockerfile -t bar.azurecr.io/test:latest",
+			[]string{"bar.azurecr.io/test:latest"},
+		},
 	}
 	for _, test := range tests {
-		actual, actualTags := PrefixTags(test.cmd, test.registry)
+		actual, actualTags := PrefixTags(test.cmd, test.registry, test.allKnownRegistries)
 		if actual != test.expected {
 			t.Errorf("expected %s, got %s", test.expected, actual)
 		}


### PR DESCRIPTION
**Purpose of the PR**

In `acb build` command, the code always tries to prefix image tag with `registry`. However if the customer wants to build and push the image to another registry, the code unexpectedly alter the tag.

The change collects all known registries form the command option and skip the prefix if the tag already contains the registry.