### PR TITLE
fix build issue with linter upgrade

### DIFF
--- a/cmd/acb/commands/exec/exec.go
+++ b/cmd/acb/commands/exec/exec.go
@@ -150,7 +150,7 @@ var Command = cli.Command{
 			taskFile = defaultTaskFile
 		}
 
-		ctx := gocontext.WithValue(gocontext.Background(), "debug", debug)
+		ctx := gocontext.Background()
 		pm := procmanager.NewProcManager(dryRun)
 
 		if homevol == "" {
@@ -228,7 +228,7 @@ var Command = cli.Command{
 			if aliasErr != nil {
 				return errors.Wrap(aliasErr, "unable to search/replace aliases in task")
 			}
-			if ctx.Value("debug").(bool) {
+			if debug {
 				log.Printf("Processed task before rendering data:\n%s", processedTask)
 			}
 			// update the template.Data
@@ -239,7 +239,7 @@ var Command = cli.Command{
 		if err != nil {
 			return errors.Wrap(err, "unable to render task")
 		}
-		if ctx.Value("debug").(bool) {
+		if debug {
 			log.Printf("Rendered template:\n%s", rendered)
 		}
 

--- a/pkg/procmanager/procmanager.go
+++ b/pkg/procmanager/procmanager.go
@@ -130,7 +130,7 @@ func (pm *ProcManager) Run(
 		return nil
 	}
 
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := exec.Command(args[0], args[1:]...) //#nosec G204
 	if cmdDir != "" {
 		cmd.Dir = cmdDir
 	}

--- a/scripts/setup/dev_setup
+++ b/scripts/setup/dev_setup
@@ -3,4 +3,4 @@
 set -e -o pipefail
 
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.20.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.20.1
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.27.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0

--- a/scripts/setup/dev_setup
+++ b/scripts/setup/dev_setup
@@ -3,4 +3,4 @@
 set -e -o pipefail
 
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.17.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.20.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.20.1


### PR DESCRIPTION
**Purpose of the PR**

- added linter tag so gosec ignores build rule G204 just for line of code causing build to fail
- upgraded golangci-lint to v1.20.1
- working on fixing errors produced by upgrading to v1.27.0

Fixes #533  