### PR TITLE
extend default push timeout to 1 hour

### DIFF
--- a/cmd/acb/commands/build/build.go
+++ b/cmd/acb/commands/build/build.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	buildTimeoutInSec = 60 * 60 * 8 // 8 hours
-	pushTimeoutInSec  = 60 * 30     // 30 minutes
+	pushTimeoutInSec  = 60 * 60     // 1 hour
 )
 
 // Command executes a container build.


### PR DESCRIPTION
**Purpose of the PR**

- extend default push timeout for build command to 1 hour, it's to handle the large image push

