### PR TITLE
fix acr build for git links without master branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
+	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
@@ -29,6 +30,7 @@ require (
 	github.com/urfave/cli v1.21.0
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	gopkg.in/yaml.v2 v2.2.2
+	gotest.tools/v3 v3.0.3
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -345,6 +346,8 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/scan/git.go
+++ b/scan/git.go
@@ -151,7 +151,8 @@ func checkoutGit(root, ref, subdir string) (string, error) {
 	// Try checking out by ref name first. This will work on branches and sets
 	// .git/HEAD to the current branch name
 	if output, err := gitWithinDir(root, "checkout", ref); err != nil {
-		// If the branch name is specified, throw an error
+		// If the branch name is specified, then it means the branch does not exist,
+		// so throw an error
 		if ref != "" {
 			return "", errors.Wrapf(err, "error checking out %s: %s", ref, output)
 		}

--- a/scan/git.go
+++ b/scan/git.go
@@ -151,9 +151,14 @@ func checkoutGit(root, ref, subdir string) (string, error) {
 	// Try checking out by ref name first. This will work on branches and sets
 	// .git/HEAD to the current branch name
 	if output, err := gitWithinDir(root, "checkout", ref); err != nil {
-		// If checking out by branch name fails check out the last fetched ref
-		if _, err2 := gitWithinDir(root, "checkout", "FETCH_HEAD"); err2 != nil {
+		// If the branch name is specified, throw an error
+		if ref != "" {
 			return "", errors.Wrapf(err, "error checking out %s: %s", ref, output)
+		}
+
+		// If the branch name is not specified, check out the last fetched ref
+		if output2, err2 := gitWithinDir(root, "checkout", "FETCH_HEAD"); err2 != nil {
+			return "", errors.Wrapf(err, "error checking out (no specified branch): %s", output2)
 		}
 	}
 
@@ -232,7 +237,7 @@ func fetchArgs(remoteURL string, ref string) []string {
 // ref: https://github.com/moby/moby/blob/master/builder/remotecontext/git/gitutils.go
 func getRefAndSubdir(fragment string) (ref string, subdir string) {
 	refAndDir := strings.SplitN(fragment, ":", 2)
-	ref = "master"
+	ref = ""
 	if refAndDir[0] != "" {
 		ref = refAndDir[0]
 	}

--- a/scan/git_test.go
+++ b/scan/git_test.go
@@ -78,6 +78,23 @@ func TestParseRemoteURL(t *testing.T) {
 				subdir: "mydir/mysubdir/",
 			},
 		},
+		{
+			doc: "Azure DevOps Git URL, no url-fragment",
+			url: "https://azure.visualstudio.com/ACR/_git/Build/",
+			expected: gitRepo{
+				remote: "https://azure.visualstudio.com/ACR/_git/Build/",
+				ref:    "",
+			},
+		},
+		{
+			doc: "Azure DevOps Git URL, with url-fragment",
+			url: "https://azure.visualstudio.com/ACR/_git/Build/#mybranch:mydir/mysubdir/",
+			expected: gitRepo{
+				remote: "https://azure.visualstudio.com/ACR/_git/Build/",
+				ref:    "mybranch",
+				subdir: "mydir/mysubdir/",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/scan/git_test.go
+++ b/scan/git_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package scan
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		doc      string
+		url      string
+		expected gitRepo
+	}{
+		{
+			doc: "git scheme, no url-fragment",
+			url: "git://github.com/user/repo.git",
+			expected: gitRepo{
+				remote: "git://github.com/user/repo.git",
+				ref:    "",
+			},
+		},
+		{
+			doc: "git scheme, with url-fragment",
+			url: "git://github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: gitRepo{
+				remote: "git://github.com/user/repo.git",
+				ref:    "mybranch",
+				subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			doc: "https scheme, no url-fragment",
+			url: "https://github.com/user/repo.git",
+			expected: gitRepo{
+				remote: "https://github.com/user/repo.git",
+				ref:    "",
+			},
+		},
+		{
+			doc: "https scheme, with url-fragment",
+			url: "https://github.com/user/repo.git#mybranch:mydir/mysubdir/",
+			expected: gitRepo{
+				remote: "https://github.com/user/repo.git",
+				ref:    "mybranch",
+				subdir: "mydir/mysubdir/",
+			},
+		},
+		{
+			doc: "git@, no url-fragment",
+			url: "git@github.com:user/repo.git",
+			expected: gitRepo{
+				remote: "git@github.com:user/repo.git",
+				ref:    "",
+			},
+		},
+		{
+			doc: "git@, with url-fragment",
+			url: "git@github.com:user/repo.git#mybranch:mydir/mysubdir/",
+			expected: gitRepo{
+				remote: "git@github.com:user/repo.git",
+				ref:    "mybranch",
+				subdir: "mydir/mysubdir/",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			repo, err := parseRemoteURL(tc.url)
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(tc.expected, repo, cmp.AllowUnexported(gitRepo{})))
+		})
+	}
+}
+
+func TestCloneArgsSmartHttp(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	serverURL, _ := url.Parse(server.URL)
+
+	serverURL.Path = "/repo.git"
+
+	mux.HandleFunc("/repo.git/info/refs", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("service")
+		w.Header().Set("Content-Type", fmt.Sprintf("application/x-%s-advertisement", q))
+	})
+
+	args := fetchArgs(serverURL.String(), "main")
+	exp := []string{"fetch", "--depth", "1", "origin", "main"}
+	assert.Check(t, is.DeepEqual(exp, args))
+}
+
+func TestCloneArgsDumbHttp(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	serverURL, _ := url.Parse(server.URL)
+
+	serverURL.Path = "/repo.git"
+
+	mux.HandleFunc("/repo.git/info/refs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+	})
+
+	args := fetchArgs(serverURL.String(), "main")
+	exp := []string{"fetch", "origin", "main"}
+	assert.Check(t, is.DeepEqual(exp, args))
+}
+
+func TestCloneArgsGit(t *testing.T) {
+	args := fetchArgs("git://github.com/docker/docker", "main")
+	exp := []string{"fetch", "--depth", "1", "origin", "main"}
+	assert.Check(t, is.DeepEqual(exp, args))
+}
+
+func gitGetConfig(name string) string {
+	b, err := git([]string{"config", "--get", name}...)
+	if err != nil {
+		// since we are interested in empty or non empty string,
+		// we can safely ignore the err here.
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func TestCheckoutGit(t *testing.T) {
+	root, err := ioutil.TempDir("", "docker-build-git-checkout")
+	assert.NilError(t, err)
+	defer os.RemoveAll(root)
+
+	autocrlf := gitGetConfig("core.autocrlf")
+	if !(autocrlf == "true" || autocrlf == "false" ||
+		autocrlf == "input" || autocrlf == "") {
+		t.Logf("unknown core.autocrlf value: \"%s\"", autocrlf)
+	}
+	eol := "\n"
+	if autocrlf == "true" {
+		eol = "\r\n"
+	}
+
+	gitDir := filepath.Join(root, "repo")
+	_, err = git("init", gitDir)
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "config", "user.email", "test@docker.com")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "config", "user.name", "Docker test")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "checkout", "-b", "default")
+	assert.NilError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch"), 0644)
+	assert.NilError(t, err)
+
+	subDir := filepath.Join(gitDir, "subdir")
+	assert.NilError(t, os.Mkdir(subDir, 0755))
+
+	err = ioutil.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 5000"), 0644)
+	assert.NilError(t, err)
+
+	if runtime.GOOS != "windows" {
+		if err = os.Symlink("../subdir", filepath.Join(gitDir, "parentlink")); err != nil {
+			t.Fatal(err)
+		}
+
+		if err = os.Symlink("/subdir", filepath.Join(gitDir, "absolutelink")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err = gitWithinDir(gitDir, "add", "-A")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "commit", "-am", "First commit")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "checkout", "-b", "test")
+	assert.NilError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(gitDir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 3000"), 0644)
+	assert.NilError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte("FROM busybox\nEXPOSE 5000"), 0644)
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "add", "-A")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "commit", "-am", "Branch commit")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "checkout", "default")
+	assert.NilError(t, err)
+
+	// set up submodule
+	subrepoDir := filepath.Join(root, "subrepo")
+	_, err = git("init", subrepoDir)
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(subrepoDir, "config", "user.email", "test@docker.com")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(subrepoDir, "config", "user.name", "Docker test")
+	assert.NilError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(subrepoDir, "subfile"), []byte("subcontents"), 0644)
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(subrepoDir, "add", "-A")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial")
+	assert.NilError(t, err)
+
+	cmd := exec.Command("git", "submodule", "add", subrepoDir, "sub") // this command doesn't work with --work-tree
+	cmd.Dir = gitDir
+	assert.NilError(t, cmd.Run())
+
+	_, err = gitWithinDir(gitDir, "add", "-A")
+	assert.NilError(t, err)
+
+	_, err = gitWithinDir(gitDir, "commit", "-am", "With submodule")
+	assert.NilError(t, err)
+
+	type singleCase struct {
+		frag      string
+		exp       string
+		fail      bool
+		submodule bool
+	}
+
+	cases := []singleCase{
+		{"", "FROM scratch", false, true},
+		{"default", "FROM scratch", false, true},
+		{":subdir", "FROM scratch" + eol + "EXPOSE 5000", false, false},
+		{":nosubdir", "", true, false},   // missing directory error
+		{":Dockerfile", "", true, false}, // not a directory error
+		{"default:nosubdir", "", true, false},
+		{"default:subdir", "FROM scratch" + eol + "EXPOSE 5000", false, false},
+		{"default:../subdir", "", true, false},
+		{"test", "FROM scratch" + eol + "EXPOSE 3000", false, false},
+		{"test:", "FROM scratch" + eol + "EXPOSE 3000", false, false},
+		{"test:subdir", "FROM busybox" + eol + "EXPOSE 5000", false, false},
+	}
+
+	if runtime.GOOS != "windows" {
+		// Windows GIT (2.7.1 x64) does not support parentlink/absolutelink. Sample output below
+		// 	git --work-tree .\repo --git-dir .\repo\.git add -A
+		//	error: readlink("absolutelink"): Function not implemented
+		// 	error: unable to index file absolutelink
+		// 	fatal: adding files failed
+		fmt.Println("Windows!!!!!!!!!!")
+		cases = append(cases, singleCase{frag: "master:absolutelink", exp: "FROM scratch" + eol + "EXPOSE 5000", fail: false})
+		cases = append(cases, singleCase{frag: "master:parentlink", exp: "FROM scratch" + eol + "EXPOSE 5000", fail: false})
+	}
+
+	for _, c := range cases {
+		testroot, err := ioutil.TempDir("", "docker-build-git-checkout-test")
+		assert.NilError(t, err)
+		defer os.RemoveAll(testroot)
+
+		ref, subdir := getRefAndSubdir(c.frag)
+		r, err := cloneGitRepo(gitRepo{remote: gitDir, ref: ref, subdir: subdir}, testroot)
+
+		if c.fail {
+			assert.Check(t, is.ErrorContains(err, ""))
+			continue
+		}
+		assert.NilError(t, err)
+		defer os.RemoveAll(r)
+		if c.submodule {
+			b, err := ioutil.ReadFile(filepath.Join(r, "sub/subfile"))
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal("subcontents", string(b)))
+		} else {
+			_, err := os.Stat(filepath.Join(r, "sub/subfile"))
+			assert.Assert(t, is.ErrorContains(err, ""))
+			assert.Assert(t, os.IsNotExist(err))
+		}
+
+		b, err := ioutil.ReadFile(filepath.Join(r, "Dockerfile"))
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(c.exp, string(b)))
+	}
+}
+
+func TestValidGitTransport(t *testing.T) {
+	gitUrls := []string{
+		"git://github.com/docker/docker",
+		"git@github.com:docker/docker.git",
+		"git@bitbucket.org:atlassianlabs/atlassian-docker.git",
+		"https://github.com/docker/docker.git",
+		"http://github.com/docker/docker.git",
+		"http://github.com/docker/docker.git#branch",
+		"http://github.com/docker/docker.git#:dir",
+	}
+	incompleteGitUrls := []string{
+		"github.com/docker/docker",
+	}
+
+	for _, url := range gitUrls {
+		if !isGitTransport(url) {
+			t.Fatalf("%q should be detected as valid Git prefix", url)
+		}
+	}
+
+	for _, url := range incompleteGitUrls {
+		if isGitTransport(url) {
+			t.Fatalf("%q should not be detected as valid Git prefix", url)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose of the PR**

The default branch of a git repo is not always "master".
github.com/repo.git => we should always use default branch no matter master exists or not or master is default or not
github.com/repo.git#dev => we should respect the settings, if dev doesn't exist, the download code should return error.
- 

Fixes #