### PR TITLE
[buildkit] fetch digest from remote

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -162,18 +162,20 @@ func (b *Builder) RunTask(ctx context.Context, task *graph.Task) error {
 	var deps []*image.Dependencies
 	for _, step := range task.Steps {
 		log.Printf("Step ID: %v marked as %v (elapsed time in seconds: %f)\n", step.ID, step.StepStatus, step.EndTime.Sub(step.StartTime).Seconds())
-		// currently we have a limitation where we cannot fetch the digest of the dependencies
-		// because we build the image using buildx, but query the digest using docker.
-		// https://github.com/Azure/acr-builder/issues/522
-		if step.UseBuildCacheForBuildStep() && runtime.GOOS == util.LinuxOS {
-			continue
-		}
+
 		if len(step.ImageDependencies) > 0 {
 			log.Printf("Populating digests for step ID: %s...\n", step.ID)
 			timeout := time.Duration(digestsTimeoutInSec) * time.Second
 			digestCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
-			if err := b.populateDigests(digestCtx, step.ImageDependencies); err != nil {
+
+			usingBuildkit := false
+			if (step.UseBuildCacheForBuildStep() && runtime.GOOS == util.LinuxOS) || step.UsesBuildkit {
+				log.Printf("Image was built using buildkit, fetching Digest from remote...")
+				usingBuildkit = true
+			}
+
+			if err := b.getPopulateDigests(digestCtx, step.ImageDependencies, usingBuildkit, task.RegistryLoginCredentials); err != nil {
 				return err
 			}
 			log.Printf("Successfully populated digests for step ID: %s\n", step.ID)
@@ -342,83 +344,29 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step, credentials []*
 		step.IgnoreErrors)
 }
 
-// populateDigests populates digests on dependencies
-func (b *Builder) populateDigests(ctx context.Context, dependencies []*image.Dependencies) error {
+// getPopulateDigests populates digests on dependencies
+func (b *Builder) getPopulateDigests(ctx context.Context, dependencies []*image.Dependencies, usingBuildkit bool, registryCreds graph.RegistryLoginCredentials) error {
+	var digestFetcher DigestHelper
+
+	if usingBuildkit {
+		digestFetcher = NewRemoteDigest(registryCreds)
+	} else {
+		digestFetcher = NewDockerStoreDigest(b.procManager, b.debug)
+	}
 	for _, entry := range dependencies {
-		if err := b.queryDigest(ctx, entry.Image); err != nil {
+		if err := digestFetcher.PopulateDigest(ctx, entry.Image); err != nil {
 			return err
 		}
-		if err := b.queryDigest(ctx, entry.Runtime); err != nil {
+		if err := digestFetcher.PopulateDigest(ctx, entry.Runtime); err != nil {
 			return err
 		}
 		for _, buildtime := range entry.Buildtime {
-			if err := b.queryDigest(ctx, buildtime); err != nil {
+			if err := digestFetcher.PopulateDigest(ctx, buildtime); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
-}
-
-func (b *Builder) queryDigest(ctx context.Context, reference *image.Reference) error {
-	if reference != nil {
-		// refString will always have the tag specified at this point.
-		// For "scratch", we have to compare it against "scratch:latest" even though
-		// scratch:latest isn't valid in a FROM clause.
-		if reference.Reference == NoBaseImageSpecifierLatest {
-			return nil
-		}
-		args := []string{
-			"docker",
-			"run",
-			"--rm",
-
-			// Mount home
-			"--volume", util.DockerSocketVolumeMapping,
-			"--volume", homeVol + ":" + homeWorkDir,
-			"--env", homeEnv,
-
-			"docker",
-			"inspect",
-			"--format",
-			"\"{{json .RepoDigests}}\"",
-			reference.Reference,
-		}
-		if b.debug {
-			log.Printf("query digest args: %v\n", args)
-		}
-		var buf bytes.Buffer
-		if err := b.procManager.Run(ctx, args, nil, &buf, &buf, ""); err != nil {
-			return errors.Wrapf(err, "failed to query digests, msg: %s", buf.String())
-		}
-		trimCharPredicate := func(c rune) bool {
-			return c == '\n' || c == '\r' || c == '"' || c == '\t'
-		}
-		reference.Digest = getRepoDigest(strings.TrimFunc(buf.String(), trimCharPredicate), reference)
-	}
-
-	return nil
-}
-
-func getRepoDigest(jsonContent string, reference *image.Reference) string {
-	prefix := reference.Repository + "@"
-	// If the reference has "library/" prefixed, we have to remove it - otherwise
-	// we'll fail to query the digest, since image names aren't prefixed with "library/"
-	if strings.HasPrefix(prefix, "library/") && reference.Registry == DockerHubRegistry {
-		prefix = prefix[8:]
-	} else if len(reference.Registry) > 0 && reference.Registry != DockerHubRegistry {
-		prefix = reference.Registry + "/" + prefix
-	}
-	var digestList []string
-	if err := json.Unmarshal([]byte(jsonContent), &digestList); err != nil {
-		log.Printf("Error deserializing %s to json, error: %v\n", jsonContent, err)
-	}
-	for _, digest := range digestList {
-		if strings.HasPrefix(digest, prefix) {
-			return digest[len(prefix):]
-		}
-	}
-	return ""
 }
 
 func validateDockerContext(sourceContext string) {

--- a/builder/digest.go
+++ b/builder/digest.go
@@ -1,0 +1,11 @@
+package builder
+
+import (
+	"context"
+
+	"github.com/Azure/acr-builder/pkg/image"
+)
+
+type DigestHelper interface {
+	PopulateDigest(ctx context.Context, reference *image.Reference) error
+}

--- a/builder/digest_docker.go
+++ b/builder/digest_docker.go
@@ -1,0 +1,89 @@
+package builder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/Azure/acr-builder/pkg/image"
+	"github.com/Azure/acr-builder/pkg/procmanager"
+	"github.com/Azure/acr-builder/util"
+	"github.com/pkg/errors"
+)
+
+type dockerStoreDigest struct {
+	procManager *procmanager.ProcManager
+	debug       bool
+}
+
+func NewDockerStoreDigest(procManager *procmanager.ProcManager, debug bool) *dockerStoreDigest {
+	return &dockerStoreDigest{
+		procManager: procManager,
+		debug:       debug,
+	}
+}
+
+var _ DigestHelper = &dockerStoreDigest{}
+
+func (d *dockerStoreDigest) PopulateDigest(ctx context.Context, reference *image.Reference) error {
+	if reference == nil {
+		return nil
+	}
+	// refString will always have the tag specified at this point.
+	// For "scratch", we have to compare it against "scratch:latest" even though
+	// scratch:latest isn't valid in a FROM clause.
+	if reference.Reference == NoBaseImageSpecifierLatest {
+		return nil
+	}
+	args := []string{
+		"docker",
+		"run",
+		"--rm",
+
+		// Mount home
+		"--volume", util.DockerSocketVolumeMapping,
+		"--volume", homeVol + ":" + homeWorkDir,
+		"--env", homeEnv,
+
+		"docker",
+		"inspect",
+		"--format",
+		"\"{{json .RepoDigests}}\"",
+		reference.Reference,
+	}
+	if d.debug {
+		log.Printf("query digest args: %v\n", args)
+	}
+	var buf bytes.Buffer
+	if err := d.procManager.Run(ctx, args, nil, &buf, &buf, ""); err != nil {
+		return errors.Wrapf(err, "failed to query digests, msg: %s", buf.String())
+	}
+	trimCharPredicate := func(c rune) bool {
+		return c == '\n' || c == '\r' || c == '"' || c == '\t'
+	}
+	reference.Digest = getRepoDigest(strings.TrimFunc(buf.String(), trimCharPredicate), reference)
+	return nil
+}
+
+func getRepoDigest(jsonContent string, reference *image.Reference) string {
+	prefix := reference.Repository + "@"
+	// If the reference has "library/" prefixed, we have to remove it - otherwise
+	// we'll fail to query the digest, since image names aren't prefixed with "library/"
+	if strings.HasPrefix(prefix, "library/") && reference.Registry == DockerHubRegistry {
+		prefix = prefix[8:]
+	} else if len(reference.Registry) > 0 && reference.Registry != DockerHubRegistry {
+		prefix = reference.Registry + "/" + prefix
+	}
+	var digestList []string
+	if err := json.Unmarshal([]byte(jsonContent), &digestList); err != nil {
+		log.Printf("Error deserializing %s to json, error: %v\n", jsonContent, err)
+	}
+	for _, digest := range digestList {
+		if strings.HasPrefix(digest, prefix) {
+			return digest[len(prefix):]
+		}
+	}
+	return ""
+}

--- a/builder/digest_docker.go
+++ b/builder/digest_docker.go
@@ -31,6 +31,9 @@ func (d *dockerStoreDigest) PopulateDigest(ctx context.Context, reference *image
 	if reference == nil {
 		return nil
 	}
+	if reference.Digest != "" {
+		return nil
+	}
 	// refString will always have the tag specified at this point.
 	// For "scratch", we have to compare it against "scratch:latest" even though
 	// scratch:latest isn't valid in a FROM clause.

--- a/builder/digest_remote.go
+++ b/builder/digest_remote.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/acr-builder/graph"
 	"github.com/Azure/acr-builder/pkg/image"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -32,6 +31,9 @@ func (d *remoteDigest) PopulateDigest(ctx context.Context, ref *image.Reference)
 	if ref.Digest != "" {
 		return nil
 	}
+	if ref.Reference == NoBaseImageSpecifierLatest {
+		return nil
+	}
 	client := http.DefaultClient
 	opts := docker.ResolverOptions{
 		Client: client,
@@ -51,30 +53,14 @@ func (d *remoteDigest) PopulateDigest(ctx context.Context, ref *image.Reference)
 	if err != nil {
 		return err
 	}
-	// Note: (bug), if the final image is NOT pushed in this build,
-	// Then the `Resolve` command below will resolve the digest of the LAST pushed image with the same tag (IFF tag is provided)
-	// Then, the unwanted behavior of runtime dependencies found in THIS run being tracked on OLD image occurs. 
-	// For ex., consider following step:
-	// - id: build
-	//   build: -t $Registry/acb:latest -f Dockerfile .
-	//   env: ["DOCKER_BUILDKIT=1"]
-	// 
-	// Since we do not push the final image "acb:latest", `Resolve` will get digest of the "acb:latest" IFF it was ever pushed before. 
-	// Lets assume old digest was sha256:xyz
-	// Then, "$Registry/acb:latest" with digest "sha256:xyz" will start to track dependencies from THIS run.
-	// But, I assume MOST tasks always Push after Build, so the dependencies are tracked on the last Pushed digest, so it won't be an issue in MOST cases.
-	// TODO: We need to skip attaching the digest to the final image if the final image wasn't pushed in this Task run.
+
 	_, desc, err := resolver.Resolve(ctx, imageRef)
-	if err == nil {
-		ref.Digest = desc.Digest.String()
-		return nil
-	}
-	// If the final image is not pushed ever, it will not have any digest.
-	if errdefs.IsNotFound(err) {
-		return nil
+	if err != nil {
+		return errors.Wrapf(err, "Failed to Resolve the reference '%s'", ref.Reference)
 	}
 
-	return errors.Wrapf(err, "Failed to Resolve the reference '%s'", ref.Reference)
+	ref.Digest = desc.Digest.String()
+	return nil
 }
 
 func getReferencePath(ref *image.Reference) (string, error) {

--- a/builder/digest_remote.go
+++ b/builder/digest_remote.go
@@ -51,12 +51,25 @@ func (d *remoteDigest) PopulateDigest(ctx context.Context, ref *image.Reference)
 	if err != nil {
 		return err
 	}
+	// Note: (bug), if the final image is NOT pushed in this build,
+	// Then the `Resolve` command below will resolve the digest of the LAST pushed image with the same tag (IFF tag is provided)
+	// Then, the unwanted behavior of runtime dependencies found in THIS run being tracked on OLD image occurs. 
+	// For ex., consider following step:
+	// - id: build
+	//   build: -t $Registry/acb:latest -f Dockerfile .
+	//   env: ["DOCKER_BUILDKIT=1"]
+	// 
+	// Since we do not push the final image "acb:latest", `Resolve` will get digest of the "acb:latest" IFF it was ever pushed before. 
+	// Lets assume old digest was sha256:xyz
+	// Then, "$Registry/acb:latest" with digest "sha256:xyz" will start to track dependencies from THIS run.
+	// But, I assume MOST tasks always Push after Build, so the dependencies are tracked on the last Pushed digest, so it won't be an issue in MOST cases.
+	// TODO: We need to skip attaching the digest to the final image if the final image wasn't pushed in this Task run.
 	_, desc, err := resolver.Resolve(ctx, imageRef)
 	if err == nil {
 		ref.Digest = desc.Digest.String()
 		return nil
 	}
-	// If the image is not pushed yet, it will not have any digest.
+	// If the final image is not pushed ever, it will not have any digest.
 	if errdefs.IsNotFound(err) {
 		return nil
 	}

--- a/builder/digest_remote.go
+++ b/builder/digest_remote.go
@@ -1,0 +1,72 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/acr-builder/graph"
+	"github.com/Azure/acr-builder/pkg/image"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
+)
+
+type remoteDigest struct {
+	registryCreds graph.RegistryLoginCredentials
+}
+
+func NewRemoteDigest(creds graph.RegistryLoginCredentials) *remoteDigest {
+	return &remoteDigest{
+		registryCreds: creds,
+	}
+}
+
+var _ DigestHelper = &remoteDigest{}
+
+func (d *remoteDigest) PopulateDigest(ctx context.Context, ref *image.Reference) error {
+	if ref == nil {
+		return nil
+	}
+	client := http.DefaultClient
+	opts := docker.ResolverOptions{
+		Client: client,
+	}
+	if cred, ok := d.registryCreds[ref.Registry]; ok {
+		if cred.Username.ResolvedValue == "" || cred.Password.ResolvedValue == "" {
+			return fmt.Errorf("Error fetching credentials for '%s'", ref.Registry)
+		}
+		// Adds credential resolver if private registry
+		opts.Credentials = func(hostName string) (string, string, error) {
+			return cred.Username.ResolvedValue, cred.Password.ResolvedValue, nil
+		}
+	}
+
+	resolver := docker.NewResolver(opts)
+	imageRef, err := getReferencePath(ref)
+	if err != nil {
+		return err
+	}
+	_, desc, err := resolver.Resolve(ctx, imageRef)
+
+	// If the image is not pushed yet, it will not have any digest.
+	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "not found") {
+		return errors.Wrapf(err, "Failed to Resolve the reference '%s'", ref.Reference)
+	}
+	ref.Digest = desc.Digest.String()
+
+	return nil
+}
+
+func getReferencePath(ref *image.Reference) (string, error) {
+	fullRefPath := fmt.Sprintf("%s/%s", ref.Registry, ref.Repository)
+	if ref.Tag != "" {
+		fullRefPath = fmt.Sprintf("%s:%s", fullRefPath, ref.Tag)
+	}
+	fullRef, err := reference.Parse(fullRefPath)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to parse the reference %s", ref.Reference)
+	}
+	return fullRef.String(), nil
+}

--- a/graph/step.go
+++ b/graph/step.go
@@ -357,7 +357,7 @@ func addBuildCacheOptsToCmd(domain, path, tag, originalBuildCmd string) (string,
 
 func invokesBuildkit(envs []string) bool {
 	for _, env := range envs {
-		if strings.Contains(env, BUILDKIT_ENV_VAR) {
+		if env == BUILDKIT_ENV_VAR {
 			return true
 		}
 	}

--- a/graph/step.go
+++ b/graph/step.go
@@ -21,6 +21,7 @@ const (
 	ImmediateExecutionToken = "-"
 	enabled                 = "enabled"
 	disabled                = "disabled"
+	BUILDKIT_ENV_VAR        = "DOCKER_BUILDKIT=1"
 )
 
 var (
@@ -93,6 +94,7 @@ type Step struct {
 	CompletedChan chanBool
 
 	ImageDependencies    []*image.Dependencies
+	UsesBuildkit         bool
 	Tags                 []string
 	BuildArgs            []string
 	DefaultBuildCacheTag string
@@ -141,6 +143,11 @@ func (s *Step) Validate() error {
 
 	if s.Cache != "" && !strings.EqualFold(s.Cache, enabled) && !strings.EqualFold(s.Cache, disabled) {
 		return errInvalidCacheValue
+	}
+
+	// check if the build step contains buildkit ENV var
+	if s.IsBuildStep() {
+		s.UsesBuildkit = invokesBuildkit(s.Envs)
 	}
 
 	return nil
@@ -346,4 +353,13 @@ func addBuildCacheOptsToCmd(domain, path, tag, originalBuildCmd string) (string,
 		return "", errors.Wrap(err, "failed to attach cache ID tag to the repo for build cache")
 	}
 	return fmt.Sprintf("--load --cache-to=type=registry,ref=%s,mode=max --cache-from=type=registry,ref=%s %s", cacheImage.String(), cacheImage.String(), originalBuildCmd), nil
+}
+
+func invokesBuildkit(envs []string) bool {
+	for _, env := range envs {
+		if strings.Contains(env, BUILDKIT_ENV_VAR) {
+			return true
+		}
+	}
+	return false
 }

--- a/scan/dependencies.go
+++ b/scan/dependencies.go
@@ -147,6 +147,9 @@ func NewImageReference(imagePath string) (*image.Reference, error) {
 	if tagged, ok := ref.(reference.Tagged); ok {
 		result.Tag = tagged.Tag()
 	}
+	if digested, ok := ref.(reference.Digested); ok {
+		result.Digest = digested.Digest().String()
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
**Purpose of the PR**

- buildkit cannot get the built image dependencies using `docker image inspect`
- So it the manifest digest from the remote registry when buildkit is used.


Fixes #522 and #574