### PR TITLE
install git lfs on system level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG GIT_LFS_VERSION=2.5.2
 # disable prompt asking for credential
 ENV GIT_TERMINAL_PROMPT 0
 RUN mkdir -p git-lfs && wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz | tar xz -C git-lfs; \
-	mv git-lfs/git-lfs /usr/bin/ && rm -rf git-lfs && git lfs install
+	mv git-lfs/git-lfs /usr/bin/ && rm -rf git-lfs && git lfs install --system
 
 COPY --from=acb /usr/bin/acb /usr/bin/acb
 ENTRYPOINT [ "acb" ]

--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -48,7 +48,7 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_LFS_DOWNLOAD_URL); \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Installing ...'; \
-	Write-Host 'git lfs install'; git lfs install; \
+	Write-Host 'git lfs install'; git lfs install --system; \
 	\
 	Write-Host 'Complete.';
 

--- a/baseimages/docker-cli/Dockerfile
+++ b/baseimages/docker-cli/Dockerfile
@@ -7,4 +7,4 @@ ARG GIT_LFS_VERSION=2.5.2
 # disable prompt asking for credential
 ENV GIT_TERMINAL_PROMPT 0
 RUN mkdir -p git-lfs && wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz | tar xz -C git-lfs; \
- 	mv git-lfs/git-lfs /usr/bin/ && rm -rf git-lfs && git lfs install
+ 	mv git-lfs/git-lfs /usr/bin/ && rm -rf git-lfs && git lfs install --system

--- a/baseimages/docker-cli/Windows.Dockerfile
+++ b/baseimages/docker-cli/Windows.Dockerfile
@@ -52,7 +52,7 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_LFS_DOWNLOAD_URL); \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Installing ...'; \
-	Write-Host 'git lfs install'; git lfs install; \
+	Write-Host 'git lfs install'; git lfs install --system; \
 	\
 	Write-Host 'Complete.';
 


### PR DESCRIPTION
The change avoids losing git lfs setting if the default home folder is overwritten.

fix#589