### PR TITLE
Minor alias test update

### DIFF
--- a/graph/preprocessor_test.go
+++ b/graph/preprocessor_test.go
@@ -97,7 +97,7 @@ func TestResolveMapAndValidate(t *testing.T) {
 func TestLoadExternalAlias(t *testing.T) {
 	resStrings := []string{"nonexistent.yaml",
 		"https://httpstat.us/404",
-		"https://raw.githubusercontent.com/estebanreyl/preprocessor-test/master/input/valid-remote.yaml",
+		"https://raw.githubusercontent.com/Azure/acr-builder/main/graph/testdata/preprocessor/valid-remote.yaml",
 		"./testdata/preprocessor/valid-external.yaml",
 		"./testdata/preprocessor/empty-external.yaml",
 	}
@@ -249,8 +249,8 @@ func TestLoadExternalAlias(t *testing.T) {
 
 func TestAddAliasFromRemote(t *testing.T) {
 	resStrings := []string{
-		"https://raw.githubusercontent.com/estebanreyl/preprocessor-test/master/input/invalid-remote.yaml",
-		"https://raw.githubusercontent.com/estebanreyl/preprocessor-test/master/input/valid-remote.yaml",
+		"https://raw.githubusercontent.com/Azure/acr-builder/main/graph/testdata/preprocessor/invalid-remote.yaml",
+		"https://raw.githubusercontent.com/Azure/acr-builder/main/graph/testdata/preprocessor/valid-remote.yaml",
 	}
 	tests := []struct {
 		name          string

--- a/graph/testdata/preprocessor/valid-alias.yaml
+++ b/graph/testdata/preprocessor/valid-alias.yaml
@@ -5,7 +5,7 @@
 
 alias:
   src:
-    - "https://raw.githubusercontent.com/estebanreyl/preprocessor-test/master/input/valid-remote.yaml"
+    - "https://raw.githubusercontent.com/Azure/acr-builder/main/graph/testdata/preprocessor/valid-remote.yaml"
     - ./valid-external.yaml
 
   values:


### PR DESCRIPTION
**Purpose of the PR**

This minor PR switches the remote alias test to use a url created from the current repository to avoid having a dependency on a remote repository.
