### PR TITLE
fix: allow git file protocol in unit test

### DIFF
--- a/scan/git.go
+++ b/scan/git.go
@@ -102,7 +102,8 @@ func cloneGitRepo(repo gitRepo, root string) (checkoutDir string, err error) {
 		return "", err
 	}
 
-	cmd := exec.Command("git", "submodule", "update", "--init", "--recursive", "--depth=1")
+	// explicitly allow file protocol to allow local unit test
+	cmd := exec.Command("git", "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "--depth=1")
 	cmd.Dir = root
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/scan/git_test.go
+++ b/scan/git_test.go
@@ -247,7 +247,7 @@ func TestCheckoutGit(t *testing.T) {
 	_, err = gitWithinDir(subrepoDir, "commit", "-am", "Subrepo initial")
 	assert.NilError(t, err)
 
-	cmd := exec.Command("git", "submodule", "add", subrepoDir, "sub") // this command doesn't work with --work-tree
+	cmd := exec.Command("git", "-c", "protocol.file.allow=always", "submodule", "add", subrepoDir, "sub") // this command doesn't work with --work-tree
 	cmd.Dir = gitDir
 	assert.NilError(t, cmd.Run())
 


### PR DESCRIPTION
- git version (2.38.1) started to block file protocol by default, the change explicitly allows it in unit test

Fixes #624 