### PR TITLE
fix: get digest of dockerhub image prefixed with registry.hub.docker.com

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repo
-* @sajayantony @northtyphoon @juliusl @jaysterp @huanwu @chloeyin @akashsinghal @estebanreyl
+* @sajayantony @northtyphoon @juliusl @jaysterp @huanwu @chloeyin @estebanreyl @yuehaoliang-microsoft @wju-MSFT

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -71,6 +71,76 @@ func TestGetRepoDigest(t *testing.T) {
 	}
 }
 
+func TestGetRepoDigestDockerHub(t *testing.T) {
+	tests := []struct {
+		id       int
+		json     string
+		imgRef   *image.Reference
+		expected string
+	}{
+		{
+			1,
+			`["registry.hub.docker.com/library/node@sha256:466d0a05ecb1e5b9890960592311fa10c2bc6012fc27dbfdcc74abf10fc324fc"]`,
+			&image.Reference{
+				Registry:   "registry.hub.docker.com",
+				Repository: "library/node",
+				Tag:        "16",
+				Reference:  "registry.hub.docker.com/library/node:16",
+			},
+			"sha256:466d0a05ecb1e5b9890960592311fa10c2bc6012fc27dbfdcc74abf10fc324fc",
+		},
+		{
+			2,
+			`["node@sha256:466d0a05ecb1e5b9890960592311fa10c2bc6012fc27dbfdcc74abf10fc324fc"]`,
+			&image.Reference{
+				Registry:   "registry.hub.docker.com",
+				Repository: "library/node",
+				Tag:        "16",
+				Reference:  "node:16",
+			},
+			"sha256:466d0a05ecb1e5b9890960592311fa10c2bc6012fc27dbfdcc74abf10fc324fc",
+		},
+		{
+			3,
+			`["node@sha256:466d0a05ecb1e5b9890960592311fa10c2bc6012fc27dbfdcc74abf10fc324fc"]`,
+			&image.Reference{
+				Registry:   "registry.hub.docker.com",
+				Repository: "library/node",
+				Tag:        "16",
+				Reference:  "library/node:16",
+			},
+			"sha256:466d0a05ecb1e5b9890960592311fa10c2bc6012fc27dbfdcc74abf10fc324fc",
+		},
+		{
+			4,
+			`["grafana/grafana@sha256:c2a9d25b77b9a7439e56efffa916e43eda09db4f7b78526082443f9c2ee18dc0"]`,
+			&image.Reference{
+				Registry:   "registry.hub.docker.com",
+				Repository: "grafana/grafana",
+				Tag:        "latest",
+				Reference:  "grafana/grafana:latest",
+			},
+			"sha256:c2a9d25b77b9a7439e56efffa916e43eda09db4f7b78526082443f9c2ee18dc0",
+		},
+		{
+			5,
+			`["registry.hub.docker.com/grafana/grafana@sha256:c2a9d25b77b9a7439e56efffa916e43eda09db4f7b78526082443f9c2ee18dc0"]`,
+			&image.Reference{
+				Registry:   "registry.hub.docker.com",
+				Repository: "grafana/grafana",
+				Tag:        "latest",
+				Reference:  "registry.hub.docker.com/grafana/grafana:latest",
+			},
+			"sha256:c2a9d25b77b9a7439e56efffa916e43eda09db4f7b78526082443f9c2ee18dc0",
+		},
+	}
+	for _, test := range tests {
+		if actual := getRepoDigest(test.json, test.imgRef); actual != test.expected {
+			t.Errorf("invalid repo digest, test id: %d; expected %s but got %s", test.id, test.expected, actual)
+		}
+	}
+}
+
 func TestParseImageNameFromArgs(t *testing.T) {
 	tests := []struct {
 		args     string

--- a/builder/digest.go
+++ b/builder/digest.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package builder
 
 import (

--- a/builder/digest_docker.go
+++ b/builder/digest_docker.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package builder
 
 import (
@@ -72,11 +75,13 @@ func (d *dockerStoreDigest) PopulateDigest(ctx context.Context, reference *image
 
 func getRepoDigest(jsonContent string, reference *image.Reference) string {
 	prefix := reference.Repository + "@"
-	// If the reference has "library/" prefixed, we have to remove it - otherwise
+	// If the reference is in DockerHub library image format (eg, nginx:latest, library/node:16), we have to remove "/library" fix - otherwise
 	// we'll fail to query the digest, since image names aren't prefixed with "library/"
-	if strings.HasPrefix(prefix, "library/") && reference.Registry == DockerHubRegistry {
-		prefix = prefix[8:]
-	} else if len(reference.Registry) > 0 && reference.Registry != DockerHubRegistry {
+	if reference.Registry == DockerHubRegistry && !strings.HasPrefix(reference.Reference, DockerHubRegistry) {
+		if strings.HasPrefix(prefix, "library/") {
+			prefix = prefix[8:]
+		}
+	} else if len(reference.Registry) > 0 {
 		prefix = reference.Registry + "/" + prefix
 	}
 	var digestList []string

--- a/builder/digest_remote.go
+++ b/builder/digest_remote.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package builder
 
 import (


### PR DESCRIPTION
**Purpose of the PR**

- If the original image reference has `registry.hub.docker.com` prefix, we need to search the image by the reference name in the format of `registry/repository`, eg `registry.hub.docker.com/library/node` 

Fixes #643