### PR TITLE
add troubleshooting logs in acb download

### DIFF
--- a/cmd/acb/commands/download/download.go
+++ b/cmd/acb/commands/download/download.go
@@ -63,6 +63,7 @@ var Command = cli.Command{
 		// Add all creds provided by the user in the --credential flag
 		credentials, err := graph.CreateRegistryCredentialFromList(creds)
 		if err != nil {
+			log.Println("Failed to add credentials")
 			return err
 		}
 
@@ -75,16 +76,20 @@ var Command = cli.Command{
 		if util.IsRegistryArtifact(downloadCtx) {
 			registryLoginCredentials, err = graph.ResolveCustomRegistryCredentials(ctx, credentials)
 			if err != nil {
+				log.Println("Failed to resolve credentials")
 				return err
 			}
 		}
 
 		scanner, err := scan.NewScanner(pm, downloadCtx, "", destination, nil, nil, "", registryLoginCredentials)
 		if err != nil {
+			log.Println("Failed to create new scanner")
 			return err
 		}
+
 		workingDir, sha, branch, err := scanner.ObtainSourceCode(ctx, downloadCtx)
 		if err != nil {
+			log.Println("Failed to obtain source code")
 			return err
 		}
 

--- a/cmd/acb/commands/download/download.go
+++ b/cmd/acb/commands/download/download.go
@@ -60,6 +60,8 @@ var Command = cli.Command{
 			return errors.New("download requires context to be provided, see download --help")
 		}
 
+		log.Println("Downloading context")
+
 		// Add all creds provided by the user in the --credential flag
 		credentials, err := graph.CreateRegistryCredentialFromList(creds)
 		if err != nil {

--- a/scan/context.go
+++ b/scan/context.go
@@ -63,7 +63,7 @@ func (s *Scanner) getContext(ctx context.Context, scContext string) (workingDir 
 		workingDir, err := s.getContextFromGitURL(scContext)
 		return workingDir, err
 	} else if isURL {
-		fmt.Printf("Getting context from URL %s\n", scContext)
+		fmt.Println("Getting context from URL")
 		err := s.getContextFromURL(scContext)
 		return s.destinationFolder, err
 	} else if isRegistryArtifact {
@@ -92,7 +92,7 @@ func (s *Scanner) getContextFromURL(remoteURL string) (err error) {
 		var response *http.Response
 		response, err = getWithStatusError(remoteURL)
 		if err != nil {
-			return errors.Wrapf(err, "unable to download remote context from %s", remoteURL)
+			return errors.Wrap(err, "unable to download remote context")
 		}
 
 		fmt.Printf("Read context with status code %d\n", response.StatusCode)

--- a/scan/context.go
+++ b/scan/context.go
@@ -60,16 +60,20 @@ func (s *Scanner) getContext(ctx context.Context, scContext string) (workingDir 
 	}
 
 	if isSourceControlURL {
+		fmt.Println("Getting context from Git URL")
 		workingDir, err := s.getContextFromGitURL(scContext)
 		return workingDir, err
 	} else if isURL {
+		fmt.Println("Getting context from URL")
 		err := s.getContextFromURL(scContext)
 		return s.destinationFolder, err
 	} else if isRegistryArtifact {
+		fmt.Println("Getting context from registry")
 		err := s.getContextFromRegistry(ctx, util.TrimArtifactPrefix(scContext))
 		return s.destinationFolder, err
 	}
 
+	fmt.Println("Context is local")
 	return scContext, nil
 }
 

--- a/scan/context.go
+++ b/scan/context.go
@@ -93,6 +93,8 @@ func (s *Scanner) getContextFromURL(remoteURL string) (err error) {
 		return errors.Wrapf(err, "unable to download remote context from %s", remoteURL)
 	}
 
+	fmt.Printf("Read context of %d bytes", response.ContentLength)
+
 	// TODO: revamp streaming, for now just pipe to buf and discard it.
 	var buf bytes.Buffer
 	progressOutput := streamformatter.NewProgressOutput(&buf)
@@ -116,7 +118,11 @@ func (s *Scanner) getContextFromReader(r io.Reader) (err error) {
 	}
 
 	if dockerbuild.IsArchive(magic) {
+		fmt.Println("starting to untar context")
 		err = archive.Untar(buf, s.destinationFolder, nil)
+		if err != nil {
+			return errors.Wrap(err, "failed to untar context")
+		}
 	}
 
 	return err


### PR DESCRIPTION
**Purpose of the PR**
Observed some "unexpected EOF" when downloading the context, so add more logs for troubleshooting.

time="2023-10-05T16:49:50Z" level=debug msg="Output from downloading: unexpected EOF\n"
time="2023-10-05T16:49:50Z" level=warning msg="Failed to download source context. Error: exit status 1"

I think "unexpected EOF" is likely originated from _**archive.Untar()**_. This method will throw "unexpected EOF" if the content is invalid or corrupted. If so, these logs may not be very helpful. Any suggestions?

Fixes #