### PR TITLE
fix a bug in download stream

### DIFF
--- a/scan/context.go
+++ b/scan/context.go
@@ -131,7 +131,7 @@ func (s *Scanner) getContextFromReader(r io.Reader) (err error) {
 
 	if dockerbuild.IsArchive(magic) {
 		fmt.Println("starting to untar context")
-		err = archive.Untar(r, s.destinationFolder, nil)
+		err = archive.Untar(buf, s.destinationFolder, nil)
 		if err != nil {
 			return errors.Wrap(err, "failed to untar context")
 		}


### PR DESCRIPTION
**Fix a bug left in my last PR**

I forgot to revert `r` to `buf`, resulting in "failed to untar context: archive/tar: invalid tar header".
<img width="1322" alt="image" src="https://github.com/Azure/acr-builder/assets/109199020/9d158ec2-1c53-4da8-a3eb-33717f037317">
