### PR TITLE
fix: misconfigured remote digest resolver

### DIFF
--- a/builder/digest_remote_test.go
+++ b/builder/digest_remote_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package builder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/acr-builder/pkg/image"
+)
+
+func TestPopulateDigest(t *testing.T) {
+	rd := &remoteDigest{}
+	cxt := context.Background()
+	imageRef := &image.Reference{
+		Registry:   "registry.hub.docker.com",
+		Repository: "library/hello-world",
+		Tag:        "latest",
+		Reference:  "hello-world:latest",
+	}
+
+	err := rd.PopulateDigest(cxt, imageRef)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if imageRef.Digest == "" {
+		t.Fatalf("image digest is not populated")
+	}
+}


### PR DESCRIPTION
**Purpose of the PR**

- the resolver now requires both pull and resolve capabilities
- the resolver now requires pass empty credentials for anonymous access

Fixes #669