### PR TITLE
feat(download): support ado pr ref

### DIFF
--- a/scan/git.go
+++ b/scan/git.go
@@ -151,10 +151,12 @@ func gitLfs(root string) error {
 func checkoutGit(root, ref, subdir string) (string, error) {
 	// Try checking out by ref name first. This will work on branches and sets
 	// .git/HEAD to the current branch name
-	// If the reference format is "pull/{pull-request-number}/head", then checkout to
+	// If the reference format is "pull/{pull-request-number}/head" (for GitHub Repo)
+	// or "refs/pull/{pull-request-number}/merge" (for AzureDevOps Repo), then checkout to
 	// FETCH_HEAD. Previous step has already fetched the reference explicitly, and
 	// current step just needs to check out the head
-	if strings.HasPrefix(ref, "pull/") && strings.HasSuffix(ref, "/head") {
+	if (strings.HasPrefix(ref, "pull/") && strings.HasSuffix(ref, "/head")) ||
+		(strings.HasPrefix(ref, "refs/pull/") && strings.HasSuffix(ref, "/merge")) {
 		output, err := gitWithinDir(root, "checkout", "FETCH_HEAD")
 		if err != nil {
 			return "", errors.Wrapf(err, "error checking out %s: %s", ref, output)


### PR DESCRIPTION
**Purpose of the PR**
- The PR reference for AzureDevOps is `refs/pull/<PR_ID>/merge`.

Fixes #672 