### PR TITLE
chore : updated the default image tag version for acr cli

### DIFF
--- a/graph/global-defaults-linux.go
+++ b/graph/global-defaults-linux.go
@@ -13,7 +13,7 @@ Commit: "{{.Run.Commit}}"
 Branch: "{{.Run.Branch}}"
 
 # Default image aliases, can be used without $ directive in cmd
-acr: mcr.microsoft.com/acr/acr-cli:0.9
+acr: mcr.microsoft.com/acr/acr-cli:0.10
 az: mcr.microsoft.com/acr/azure-cli:ee2fd89
 bash: mcr.microsoft.com/acr/bash:ee2fd89
 curl: mcr.microsoft.com/acr/curl:ee2fd89


### PR DESCRIPTION
**Purpose of the PR**

- Updated the default image tag version for ACR CLI from 0.9 to 0.10

Fixes #
- none