### PR TITLE
chore : updated the default image tag version for acr cli from 0.10 to 0.11

### DIFF
--- a/graph/global-defaults-linux.go
+++ b/graph/global-defaults-linux.go
@@ -13,7 +13,7 @@ Commit: "{{.Run.Commit}}"
 Branch: "{{.Run.Branch}}"
 
 # Default image aliases, can be used without $ directive in cmd
-acr: mcr.microsoft.com/acr/acr-cli:0.10
+acr: mcr.microsoft.com/acr/acr-cli:0.11
 az: mcr.microsoft.com/acr/azure-cli:59ce91f
 bash: mcr.microsoft.com/acr/bash:59ce91f
 curl: mcr.microsoft.com/acr/curl:59ce91f


### PR DESCRIPTION
**Purpose of the PR**

- Updated the default image tag version for ACR CLI from 0.10 to 0.11

Fixes #

- none