### PR TITLE
fix: allow escaped version key

### DIFF
--- a/graph/preprocessor.go
+++ b/graph/preprocessor.go
@@ -312,9 +312,9 @@ func FindVersion(data []byte) string {
 		}
 
 		// use text instead of trimmedText since ' version: ' is also invalid.
-		if strings.HasPrefix(text, versionKey) {
+		if strings.HasPrefix(strings.TrimLeft(text, "'\""), versionKey) {
 			tokens := strings.SplitN(text, ":", 2)
-			if len(tokens) == 2 && strings.TrimSpace(tokens[0]) == versionKey {
+			if len(tokens) == 2 && strings.Trim(strings.TrimSpace(tokens[0]), "'\"") == versionKey {
 				return strings.Trim(strings.TrimSpace(tokens[1]), "'\"")
 			}
 		}

--- a/graph/preprocessor_test.go
+++ b/graph/preprocessor_test.go
@@ -626,12 +626,112 @@ version:   'v1.1.0'`,
 version:   "v1.1.0'`,
 			"v1.1.0",
 		},
+		{
+			`       
+"version"`,
+			"",
+		},
+		{
+			` # task.yml file
+# should be skipped
+
+"version"  : v1.1.0    
+`,
+			"v1.1.0",
+		},
+		{
+			`
+build: something
+"version": v1.1.0`,
+			"",
+		},
+		{
+			`       
+"version"`,
+			"",
+		},
+		{
+			`       
+"version":v1.1.0
+			`,
+			"v1.1.0",
+		},
+		{
+			`       
+"version":foo:bar:beta`,
+			"foo:bar:beta",
+		},
+		{
+			`       
+"version":"v1.1.0"`,
+			"v1.1.0",
+		},
+		{
+			`       
+"version":   'v1.1.0'`,
+			"v1.1.0",
+		},
+		{
+			`       
+"version":   "v1.1.0'`,
+			"v1.1.0",
+		},
+		{
+			`       
+'version'`,
+			"",
+		},
+		{
+			` # task.yml file
+# should be skipped
+
+'version'  : v1.1.0    
+`,
+			"v1.1.0",
+		},
+		{
+			`
+build: something
+'version': v1.1.0`,
+			"",
+		},
+		{
+			`       
+'version'`,
+			"",
+		},
+		{
+			`       
+'version':v1.1.0
+			`,
+			"v1.1.0",
+		},
+		{
+			`       
+'version':foo:bar:beta`,
+			"foo:bar:beta",
+		},
+		{
+			`       
+'version':"v1.1.0"`,
+			"v1.1.0",
+		},
+		{
+			`       
+'version':   'v1.1.0'`,
+			"v1.1.0",
+		},
+		{
+			`       
+'version':   "v1.1.0'`,
+			"v1.1.0",
+		},
 	}
 
 	for _, test := range tests {
 		actualVersion := FindVersion([]byte(test.task))
 		if actualVersion != test.expectedVersion {
-			t.Errorf("Expected %s but got %s", test.expectedVersion, actualVersion)
+			t.Errorf("Expected %s but got %s ---\n%v", test.expectedVersion, actualVersion, test)
 		}
 	}
 }


### PR DESCRIPTION
…because terraform will always encode escape yaml property keys

**Purpose of the PR**

- Today we do not allow `"version": v1.1.0` when finding the tasks.yaml version during preprocess. This change allows the preprocessor to find the version key if the version key has been escaped.

Fixes #685