### PR TITLE
fix: find version checks entire file and not just first line

### DIFF
--- a/graph/preprocessor.go
+++ b/graph/preprocessor.go
@@ -318,7 +318,6 @@ func FindVersion(data []byte) string {
 				return strings.Trim(strings.TrimSpace(tokens[1]), "'\"")
 			}
 		}
-		break
 	}
 
 	return ""

--- a/graph/preprocessor_test.go
+++ b/graph/preprocessor_test.go
@@ -588,7 +588,7 @@ version  : v1.1.0
 			`
 build: something
 version: v1.1.0`,
-			"",
+			"v1.1.0",
 		},
 		{
 			`
@@ -643,7 +643,7 @@ version:   "v1.1.0'`,
 			`
 build: something
 "version": v1.1.0`,
-			"",
+			"v1.1.0",
 		},
 		{
 			`       
@@ -693,7 +693,7 @@ build: something
 			`
 build: something
 'version': v1.1.0`,
-			"",
+			"v1.1.0",
 		},
 		{
 			`       
@@ -724,6 +724,11 @@ build: something
 		{
 			`       
 'version':   "v1.1.0'`,
+			"v1.1.0",
+		},
+		{
+			`       
+"version':   "v1.1.0'`,
 			"v1.1.0",
 		},
 	}


### PR DESCRIPTION
**Purpose of the PR**

- Today find version only checks the first line for the version. This allows the whole file to be checked instead.

Fixes #