### PR TITLE
updated acr cli version from 0.13

### DIFF
--- a/graph/global-defaults-linux.go
+++ b/graph/global-defaults-linux.go
@@ -13,7 +13,7 @@ Commit: "{{.Run.Commit}}"
 Branch: "{{.Run.Branch}}"
 
 # Default image aliases, can be used without $ directive in cmd
-acr: mcr.microsoft.com/acr/acr-cli:0.11
+acr: mcr.microsoft.com/acr/acr-cli:0.13
 az: mcr.microsoft.com/acr/azure-cli:59ce91f
 bash: mcr.microsoft.com/acr/bash:59ce91f
 curl: mcr.microsoft.com/acr/curl:59ce91f


### PR DESCRIPTION
**Purpose of the PR**

- Updated the default image tag version for ACR CLI from 0.11 to 0.13

Fixes #