### PR TITLE
fix(lint): update golangci-lint to support golang 1.24

### DIFF
--- a/scripts/setup/dev_setup
+++ b/scripts/setup/dev_setup
@@ -3,4 +3,4 @@
 set -e -o pipefail
 
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.61.0/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.64.8/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8


### PR DESCRIPTION
**Purpose of the PR**

- update golangci-lint to support golang 1.24