### PR TITLE
build: fix Code QL run for go

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,10 @@ steps:
     # Prepend wrapper to PATH
     export PATH="$(pwd)/go-wrapper-bin:$PATH"
 
+    # Install golangci-lint to GOPATH/bin
+    export PATH="$(GOPATH)/bin:$PATH"
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(GOPATH)/bin" v1.64.8
+
     # Setup as before
     GOOS=linux scripts/setup/dev_setup
     echo '##vso[task.prependpath]$(GOPATH)/bin'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
     mkdir -p go-wrapper-bin
     cat > go-wrapper-bin/go <<'EOF'
     #!/bin/sh
-    exec /usr/local/go/bin/go "$@"
+    exec /usr/bin/go "$@"
     EOF
     chmod +x go-wrapper-bin/go
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,17 +19,28 @@ steps:
 
 - script: |
     set -e
+
+    # Create Go wrapper script
+    mkdir -p go-wrapper-bin
+    cat > go-wrapper-bin/go <<'EOF'
+    #!/bin/sh
+    exec /usr/local/go/bin/go "$@"
+    EOF
+    chmod +x go-wrapper-bin/go
+
+    # Prepend wrapper to PATH
+    export PATH="$(pwd)/go-wrapper-bin:$PATH"
+
+    # Setup as before
     GOOS=linux scripts/setup/dev_setup
     echo '##vso[task.prependpath]$(GOPATH)/bin'
     mkdir -p '$(ModulePath)'
     shopt -s dotglob extglob
     mv !(work) '$(ModulePath)'
-  displayName: 'Setup'
 
-- script: |
-    set -e
+    # Build (CodeQL will now see the wrapper)
+    cd '$(ModulePath)'
     go version
     go env
     GOOS=linux make
-  workingDirectory: '$(ModulePath)'
-  displayName: 'Build'
+  displayName: 'Setup and Build (with Go wrapper)'


### PR DESCRIPTION
**Purpose of the PR**
This PR fixes the Azure Pipeline to add a wrapper script around the Go binary. This is required for CodeQL analysis to work with Go 1.21+ on Linux, since Go binaries are now statically linked and CodeQL can no longer intercept the Go compiler directly.

- Added a script step that creates a Go wrapper (go-wrapper-bin/go) and prepends it to the PATH before the build.
- The wrapper delegates to the real Go binary, allowing CodeQL to "see" the build.
- Combined setup and build into a single script step, as required for CodeQL to intercept the build.
- Ensured golangci-lint is installed to a user-writable directory ($(GOPATH)/bin) and included in the PATH.


Fixes #
Should fix below during Code QL run: 
- go   | database finalize failed   |Database failed to finalize or no source code was built!

Code QL guidance on Eng hub here - https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled#go-121-and-higher-on-linux
