### PR TITLE
build: more changes to fix code ql run for go

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,16 +20,17 @@ steps:
 - script: |
     set -e
 
-    # Create Go wrapper script
-    mkdir -p go-wrapper-bin
-    cat > go-wrapper-bin/go <<'EOF'
-    #!/bin/sh
-    exec /usr/bin/go "$@"
+    # Static binary workaround for CodeQL and Go 1.21+
+    mkdir -p $AGENT_TEMPDIRECTORY/codeql-go-tracing
+    WORKAROUND_DIR=$AGENT_TEMPDIRECTORY/codeql-go-tracing
+    WHICH_GO=$(which go)
+    cat > "${WORKAROUND_DIR}/go" <<EOF
+    #!/bin/bash
+    exec $WHICH_GO "\$@"
     EOF
-    chmod +x go-wrapper-bin/go
 
-    # Prepend wrapper to PATH
-    export PATH="$(pwd)/go-wrapper-bin:$PATH"
+    chmod 755 "${WORKAROUND_DIR}/go"
+    export PATH="${WORKAROUND_DIR}:${PATH}"
 
     # Install golangci-lint to GOPATH/bin
     export PATH="$(GOPATH)/bin:$PATH"
@@ -42,9 +43,13 @@ steps:
     shopt -s dotglob extglob
     mv !(work) '$(ModulePath)'
 
-    # Build (CodeQL will now see the wrapper)
-    cd '$(ModulePath)'
+    # Confirm wrapper is used
+    echo "Go in PATH: $(which go)"
+    cat $(which go)
     go version
     go env
+
+    # Build (CodeQL will now see the wrapper)
+    cd '$(ModulePath)'
     GOOS=linux make
   displayName: 'Setup and Build (with Go wrapper)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,5 +51,6 @@ steps:
 
     # Build (CodeQL will now see the wrapper)
     cd '$(ModulePath)'
+    go build ./...
     GOOS=linux make
   displayName: 'Setup and Build (with Go wrapper)'


### PR DESCRIPTION
**Purpose of the PR**
- Attempting to fix code ql run for Go

**Fixes #**
- Moved the Go wrapper script from a local directory to the recommended temporary agent directory to adhere to MS code ql guidance here - https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/onboarding/language-compiled#go-121-and-higher-on-linux
- Dynamically detecting the Go binary location using which go instead of hardcoding the path
- Prepended the wrapper directory to the PATH using the agent temp directory, ensuring the wrapper is used for all go invocations during the build.