### PR TITLE
fix: pre-run windows server 2019 containers to prevent startup issues

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -344,16 +344,17 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step, credentials []*
 			}
 
 			if b.debug {
-				log.Printf("Pre-run args: %v\n", strings.Join(args, ", "))
+				log.Printf("Pre-run args: %v\n", strings.Join(preRunArgs, ", "))
 			}
 
-			// Silently run the command to not confuse the user
-			err := b.procManager.Run(ctx, preRunArgs, nil, nil, nil, "")
+			// Silently run the command to not confuse the user. Only expose error in debug mode.
+			var stdErrBuf bytes.Buffer
+			err := b.procManager.Run(ctx, preRunArgs, nil, nil, &stdErrBuf, "")
 			if b.debug {
 				if err != nil {
-					log.Println("Prevented a crash by running a pre-run container")
+					log.Printf("Pre-run ran with error: %s\n", stdErrBuf.String())
 				} else {
-					log.Printf("Pre-run ran without issues")
+					log.Printf("Pre-run ran without issues\n")
 				}
 			}
 		}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -443,7 +443,6 @@ func (b *Builder) preRunWindowsContainer(ctx context.Context, step *graph.Step) 
 	}
 }
 
-
 // prepareVolumeSource creates and populates the host file and volume for the specified source type
 func (b *Builder) prepareVolumeSource(ctx context.Context, volMount *volume.Volume) error {
 	switch {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -335,7 +335,7 @@ func (b *Builder) runStep(ctx context.Context, step *graph.Step, credentials []*
 	// without any startup issues.
 	// The current workaround is to run a throwaway container to ensure subsequent runs succeed.
 	if runtime.GOOS == util.WindowsOS && (step.Isolation == "" || step.Isolation == "hyperv") {
-		if parseImageNameFromArgs(step.Cmd) == "mcr.microsoft.com/windows/servercore:ltsc2019" || step.ContainsImageDependency("mcr.microsoft.com/windows/servercore:ltsc2019") {
+		if parseImageNameFromArgs(step.Cmd) == WindowServerCore2019Image || step.ContainsImageDependency(WindowServerCore2019Image) {
 			once.Do(func() { b.preRunWindowsContainer(stepCtx, step) })
 		}
 	}
@@ -424,7 +424,8 @@ func (b *Builder) preRunWindowsContainer(ctx context.Context, step *graph.Step) 
 		"--rm",
 		"--name", step.ID + "_prerun",
 		"--isolation", "hyperv",
-		"mcr.microsoft.com/windows/servercore:ltsc2019",
+		"--pull", "always",
+		WindowServerCore2019Image,
 	}
 
 	if b.debug {

--- a/builder/constants.go
+++ b/builder/constants.go
@@ -29,4 +29,6 @@ const (
 	buildkitdContainerInitRetryDelay      = 5 // 5 seconds
 	buildkitdContainerName                = "acrbuildkitdcontainer"
 	buildkitdContainerInitRepeat          = 0 // no repetition for retries
+
+	WindowServerCore2019Image = "mcr.microsoft.com/windows/servercore:ltsc2019"
 )

--- a/graph/step.go
+++ b/graph/step.go
@@ -367,3 +367,15 @@ func invokesBuildkit(envs []string) bool {
 	}
 	return false
 }
+
+func (s *Step) ContainsImageDependency(imageReference string) bool {
+	if s == nil || len(s.ImageDependencies) == 0 {
+		return false
+	}
+	for _, dep := range s.ImageDependencies {
+		if dep.Image != nil && dep.Image.Reference == imageReference {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**Purpose of the PR**
- [April 16, 2025—KB5059091 (OS Build 17763.7249) Out-of-band - Microsoft Support](https://support.microsoft.com/en-us/topic/april-16-2025-kb5059091-os-build-17763-7249-out-of-band-328ff8b5-7c6b-4f06-95cc-67fbd18b3ffb) introduced a bug where-in the first time a Windows Server 2019 Hyper-V container is run in Windows 2022, it has a chance of failing. This fix will silently run the container once before the user runs it, to prevent the issue