### PR TITLE
chore: update golang and system images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_CLI_BASE_IMAGE=mcr.microsoft.com/acr/moby-cli:linux-latest
 
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-fips-azurelinux3.0 AS gobuild-base
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.5-fips-azurelinux3.0 AS gobuild-base
 
 FROM gobuild-base AS acb
 RUN tdnf update -y && tdnf install make git -y

--- a/Windows.Dockerfile
+++ b/Windows.Dockerfile
@@ -63,7 +63,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 # install go lang
 
-ENV GOLANG_VERSION 1.24.4
+ENV GOLANG_VERSION 1.24.5
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -15,7 +15,7 @@ steps:
 
 - task: GoTool@0
   inputs:
-    version: '1.24.4'
+    version: '1.24.5'
 
 - script: |
     (robocopy $(system.defaultWorkingDirectory) $(ModulePath) /E /XD  $(system.defaultWorkingDirectory)\work)^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ steps:
 
 - task: GoTool@0
   inputs:
-    version: '1.24.4'
+    version: '1.24.5'
 
 - script: |
     set -e

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/acr-builder
 
-go 1.24.4
+go 1.24.5
 
 require (
 	github.com/Azure/azure-sdk-for-go v63.2.0+incompatible

--- a/graph/global-defaults-linux.go
+++ b/graph/global-defaults-linux.go
@@ -13,9 +13,9 @@ Commit: "{{.Run.Commit}}"
 Branch: "{{.Run.Branch}}"
 
 # Default image aliases, can be used without $ directive in cmd
-acr: mcr.microsoft.com/acr/acr-cli:0.15
-az: mcr.microsoft.com/acr/azure-cli:cbcf692
-bash: mcr.microsoft.com/acr/bash:cbcf692
-curl: mcr.microsoft.com/acr/curl:cbcf692
-cssc: mcr.microsoft.com/acr/cssc:cbcf692
+acr: mcr.microsoft.com/acr/acr-cli:0.16
+az: mcr.microsoft.com/acr/azure-cli:ccae46a
+bash: mcr.microsoft.com/acr/bash:ccae46a
+curl: mcr.microsoft.com/acr/curl:ccae46a
+cssc: mcr.microsoft.com/acr/cssc:ccae46a
 `


### PR DESCRIPTION
**Purpose of the PR**

- update golang to 1.24.5
- update system images